### PR TITLE
Add code-formatting pre-commit hooks and CI job

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
           
     - name: Run code formatting checks with pre-commit
       uses: pre-commit/action@v3.0.0

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -1,0 +1,19 @@
+name: Code Formatting
+on: 
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  code-formatting:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.10
+          
+    - name: Run code formatting checks with pre-commit
+      uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+    - id: check-yaml
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.0.278
+  hooks:
+    - id: ruff
+      types_or: [
+        python,
+        pyi,
+      ]
+      args: [ --fix, --exit-non-zero-on-fix]
+- repo: https://github.com/psf/black
+  rev: 23.3.0
+  hooks:
+    - id: black
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This is the development repo for the SNAX project. It is a variant of the [Snitc
 ```bash
 pip install -r requirements.txt
 ```
-
 Run tests:
 ```bash
 pytest --simulator=verilator
@@ -17,3 +16,9 @@ pytest --simulator=verilator
 You can set `--simulator` to any of the [cocotb supported simulators](https://docs.cocotb.org/en/stable/simulator_support.html).
 This option is set to `verilator` by default.
 
+# Development
+We provide pre-commit hooks to help formatting python and yaml code.
+To hook the pre-commit hooks into git, use:
+```bash
+pre-commit install
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 cocotb==1.8.0
 cocotb-test==0.2.4
 pytest==7.4.0
+pre-commit
+ruff
+black


### PR DESCRIPTION
This PR adds a set of pre-commit hooks.
When using `pre-commit install` pre-commit wil hook itself into git and will not commit unless all checks have passed, like so:
```zsh
snax-dev git:Josse/code-formatting*  
❯ git commit -m "mess up the formatting"
check yaml...........................................(no files to check)Skipped
ruff.....................................................................Passed
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted tests/cocotb/test_counter.py

All done! ✨ 🍰 ✨
1 file reformatted.
```

The added checks here are the following:
* check yaml: check yaml files
* ruff: a fast python linter
* black: a python formatter, for code formatting.

Aditionally this PR introduces a CI job that does the code-format checks. If code is not formatted properly, pull requests should not be accepted.