### PR TITLE
Change workflow triggers and change test name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
-name: Hello world workflow
-on: [push, pull_request, workflow_dispatch]
+name: Hardware Unit Tests
+on: 
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: [main]
 
 jobs:
   rtl-test-vlt:
@@ -12,3 +16,4 @@ jobs:
       - name: Running Pytest
         run: |
           pytest -v -o log_cli=True
+


### PR DESCRIPTION
Now all tests in Hardware Unit Tests in a PR are ran twice (once for the push to the branch and once for the push to a PR).
This PR changes that and changes the name from Hello world workflow to "hardware unit tests"