### PR TITLE
Add CI badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+![CI](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/code-formatting.yml/badge.svg)
+![CI](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/pyright.yml/badge.svg)
+
 #  SNAX - Snitch Accelerator Extension
 
 This is the development repo for the SNAX project. It is a variant of the [Snitch Cluster Platform](https://github.com/pulp-platform/snitch_cluster) where it focuses on heterogenous architectures. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![CI](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/ci.yml/badge.svg)
-![CI](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/code-formatting.yml/badge.svg)
-![CI](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/pyright.yml/badge.svg)
+[![CI](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/ci.yml/badge.svg)](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/ci.yml)
+[![CI](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/code-formatting.yml/badge.svg)](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/code-formatting.yml)
+[![CI](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/pyright.yml/badge.svg)](https://github.com/KULeuven-MICAS/snax-dev/actions/workflows/pyright.yml)
 
 #  SNAX - Snitch Accelerator Extension
 


### PR DESCRIPTION
This PR adds CI badges to the README. Format was copied from Snitch cluster.