### PR TITLE
Add simple shift register test from PULP common cells

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,6 @@ on:
     branches: [main]
 
 jobs:
-  rtl-test-vlt:
-    name: RTL test using verilator
-    runs-on: ubuntu-22.04
-    container:
-      image: rgantonio/snax-cocotb
-    steps:
-      - uses: actions/checkout@v3
-      - name: Running Pytest
-        run: |
-          pytest -v -o log_cli=True
-
   bender-test:
     name: Bender test
     runs-on: ubuntu-22.04
@@ -27,4 +16,20 @@ jobs:
       - name: Bender test
         run: |
           bender script flist
+
+  rtl-test-vlt:
+    name: RTL test using verilator
+    runs-on: ubuntu-22.04
+    container:
+      image: rgantonio/snax-cocotb
+    steps:
+      - uses: actions/checkout@v3
+      - name: Pull Snitch cluster files
+        run: |
+          bender script flist
+      - name: Running Pytest
+        run: |
+          pytest -v -o log_cli=True
+
+  
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,6 @@ on:
     branches: [main]
 
 jobs:
-  bender-test:
-    name: Bender test
-    runs-on: ubuntu-22.04
-    container:
-      image: rgantonio/snax-cocotb
-    steps:
-      - uses: actions/checkout@v3
-      - name: Bender test
-        run: |
-          bender script flist
-
   rtl-test-vlt:
     name: RTL test using verilator
     runs-on: ubuntu-22.04

--- a/tests/cocotb/test_shift_reg.py
+++ b/tests/cocotb/test_shift_reg.py
@@ -8,7 +8,6 @@
 # -----------------------------------
 # Imports
 # -----------------------------------
-import subprocess
 import cocotb
 from cocotb.triggers import RisingEdge
 from cocotb.clock import Clock
@@ -19,9 +18,9 @@ import pytest
 # -----------------------------------
 # Variables
 # -----------------------------------
-FIFO_DEPTH = 1
-TEST_COUNT = 10
-DATA_WIDTH = 8
+FIFO_DEPTH = 0
+TEST_COUNT = 20
+DATA_WIDTH = 16
 
 
 # -----------------------------------
@@ -60,8 +59,7 @@ async def shift_reg_dut(dut):
             output_val = 0
 
         # Log debug
-        cocotb.log.info(f"Shift reg input: {input_val}")
-        cocotb.log.info(f"Shift reg output: {output_val}")
+        cocotb.log.info(f"Shift reg input: {input_val}; Shift reg output: {output_val}")
 
         # Collect answers and expected outputs
         checker.append(input_val)
@@ -83,27 +81,16 @@ async def shift_reg_dut(dut):
 # Run setup
 # -----------------------------------
 def test_shift_reg(parameters, simulator):
-    # Working paths
-    repo_dir = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"], stdout=subprocess.PIPE
-    )
-    repo_dir = repo_dir.stdout.decode("utf-8").strip()
-    tests_path = repo_dir + "/tests/cocotb/"
-
     # RTL paths
     # TODO: Change this later. For now this is just a simple test.
     rtl_sources = [
-        repo_dir
-        + "/.bender/git/checkouts/common_cells-9e51f4fce2109f7f/src/shift_reg.sv",
-        repo_dir
-        + "/.bender/git/checkouts/common_cells-9e51f4fce2109f7f/src/shift_reg_gated.sv",
-        repo_dir + "/tests/tb/tb_shift_reg.sv",
+        ".bender/git/checkouts/common_cells-9e51f4fce2109f7f/src/shift_reg.sv",
+        ".bender/git/checkouts/common_cells-9e51f4fce2109f7f/src/shift_reg_gated.sv",
+        "tests/tb/tb_shift_reg.sv",
     ]
 
     # Include directories
-    include_folders = [
-        repo_dir + "/.bender/git/checkouts/common_cells-9e51f4fce2109f7f/include"
-    ]
+    include_folders = [".bender/git/checkouts/common_cells-9e51f4fce2109f7f/include"]
 
     # Specify top-level module
     toplevel = "tb_shift_reg"
@@ -113,7 +100,7 @@ def test_shift_reg(parameters, simulator):
     module = "test_shift_reg"
 
     # Specify build directory
-    sim_build = tests_path + "/sim_build/{}/".format(toplevel)
+    sim_build = "tests/sim_build/{}/".format(toplevel)
 
     run(
         verilog_sources=rtl_sources,

--- a/tests/cocotb/test_shift_reg.py
+++ b/tests/cocotb/test_shift_reg.py
@@ -5,9 +5,6 @@
 # Author: Ryan Antonio (ryan.antonio@esat.kuleuven.be)
 # ---------------------------------
 
-# -----------------------------------
-# Imports
-# -----------------------------------
 import subprocess
 import cocotb
 from cocotb.triggers import RisingEdge
@@ -25,44 +22,37 @@ DATA_WIDTH = 16
 
 
 # -----------------------------------
-# Stimulus
+# Test stimulus
 # -----------------------------------
 @cocotb.test()
 async def shift_reg_dut(dut):
-    # Initialize clock
     clock = Clock(dut.clk_i, 10, units="ns")
     cocotb.start_soon(clock.start())
 
-    # Reset or intial values
     dut.rst_ni.value = 0
 
-    # Wait 1 cycle to reset
     await RisingEdge(dut.clk_i)
 
-    # Deassert reset
     dut.rst_ni.value = 1
 
-    # Getting check list
     checker = [0] * (FIFO_DEPTH + 1)
     answer = []
 
-    # Iterate test cases
     for i in range(TEST_COUNT):
         input_val = random.randint(0, (2**DATA_WIDTH - 1))
         dut.d_i.value = input_val
 
         output_val = dut.d_o.value
 
-        # Workaround so that both Verilator and Modelsim pass
+        # Workaround since Verilator only outputs 1s and 0s
+        # While modelsim outputs don't care X's
         if str(output_val).isnumeric():
             output_val = int(output_val)
         else:
             output_val = 0
 
-        # Log debug
         cocotb.log.info(f"Shift reg input: {input_val}; Shift reg output: {output_val}")
 
-        # Collect answers and expected outputs
         checker.append(input_val)
         answer.append(output_val)
 
@@ -72,19 +62,14 @@ async def shift_reg_dut(dut):
 
 
 # -----------------------------------
-# Parameter inputs to DUT
+# Test build
 # -----------------------------------
 @pytest.mark.parametrize(
     "parameters", [{"DataWidth": str(DATA_WIDTH), "Depth": str(FIFO_DEPTH)}]
 )
-
-# -----------------------------------
-# Run setup
-# -----------------------------------
 def test_shift_reg(parameters, simulator):
     # RTL paths
     # Extract paths for benderized files
-    # This way is also seen on github actions
     common_cells_dir = subprocess.run(
         ["bender", "path", "common_cells"], stdout=subprocess.PIPE
     )
@@ -97,17 +82,14 @@ def test_shift_reg(parameters, simulator):
         "tests/tb/tb_shift_reg.sv",
     ]
 
-    # Include directories
     include_folders = [common_cells_dir + "/include"]
 
-    # Specify top-level module
     toplevel = "tb_shift_reg"
 
-    # Specify python test name that contains the @cocotb.test.
-    # Usually the name of this test.
+    # Module is the python test name that contains the @cocotb.test.
+    # In this example, it's the name of this test
     module = "test_shift_reg"
 
-    # Specify build directory
     sim_build = "tests/sim_build/{}/".format(toplevel)
 
     run(

--- a/tests/cocotb/test_shift_reg.py
+++ b/tests/cocotb/test_shift_reg.py
@@ -8,6 +8,7 @@
 # -----------------------------------
 # Imports
 # -----------------------------------
+import subprocess
 import cocotb
 from cocotb.triggers import RisingEdge
 from cocotb.clock import Clock
@@ -82,15 +83,22 @@ async def shift_reg_dut(dut):
 # -----------------------------------
 def test_shift_reg(parameters, simulator):
     # RTL paths
-    # TODO: Change this later. For now this is just a simple test.
+    # Extract paths for benderized files
+    # This way is also seen on github actions
+    common_cells_dir = subprocess.run(
+        ["bender", "path", "common_cells"], stdout=subprocess.PIPE
+    )
+
+    common_cells_dir = common_cells_dir.stdout.decode("utf-8").strip()
+
     rtl_sources = [
-        ".bender/git/checkouts/common_cells-9e51f4fce2109f7f/src/shift_reg.sv",
-        ".bender/git/checkouts/common_cells-9e51f4fce2109f7f/src/shift_reg_gated.sv",
+        common_cells_dir + "/src/shift_reg.sv",
+        common_cells_dir + "/src/shift_reg_gated.sv",
         "tests/tb/tb_shift_reg.sv",
     ]
 
     # Include directories
-    include_folders = [".bender/git/checkouts/common_cells-9e51f4fce2109f7f/include"]
+    include_folders = [common_cells_dir + "/include"]
 
     # Specify top-level module
     toplevel = "tb_shift_reg"

--- a/tests/cocotb/test_shift_reg.py
+++ b/tests/cocotb/test_shift_reg.py
@@ -1,0 +1,97 @@
+# ---------------------------------
+# Copyright 2023 KULeuven
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+# Author: Ryan Antonio (ryan.antonio@esat.kuleuven.be)
+# ---------------------------------
+
+# -----------------------------------
+# Imports
+# -----------------------------------
+import os
+import cocotb
+from cocotb.triggers import RisingEdge
+from cocotb.clock import Clock
+from cocotb_test.simulator import run
+import random
+import pytest
+
+'''
+    Let's do this manually first
+'''
+
+@cocotb.test()
+async def shift_reg_dut(dut):
+
+    # Debugging
+    print(dir(dut))
+
+    # Initialize clock
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start())
+
+    # Reset or intial values
+    dut.rst_ni.value = 0
+
+    # Wait 1 cycle to reset
+    await RisingEdge(dut.clk_i)
+
+    # Deassert reset
+    dut.rst_ni.value = 1
+
+    for i in range(20):
+
+        input_val = random.randint(0,1)
+        dut.d_i.value = input_val
+
+        output_val = int(dut.d_o.value)
+
+        cocotb.log.info(f'Shift reg input: {input_val}')
+        cocotb.log.info(f'Shift reg output: {output_val}')
+
+        await RisingEdge(dut.clk_i)
+
+# Main test run
+@pytest.mark.parametrize(
+    "parameters", [
+        {
+            "Depth": str(1)
+        }
+    ]
+)
+
+def test_shift_reg(parameters):
+
+    # Working paths
+    repo_path = os.getcwd()
+    tests_path = repo_path + "/tests/cocotb/"
+
+    # RTL paths
+    rtl_sources = ["/users/micas/rantonio/no_backup/snax-dev/.bender/git/checkouts/common_cells-9e51f4fce2109f7f/src/shift_reg.sv", \
+                   "/users/micas/rantonio/no_backup/snax-dev/.bender/git/checkouts/common_cells-9e51f4fce2109f7f/src/shift_reg_gated.sv"]
+    
+    # Include directories
+    include_folders = ['/users/micas/rantonio/no_backup/snax-dev/.bender/git/checkouts/common_cells-9e51f4fce2109f7f/include']
+
+    # Specify top-level module
+    toplevel = "shift_reg"
+    
+    # Specify python test name that contains the @cocotb.test.
+    # Usually the name of this test.
+    module = "test_shift_reg"
+
+    # Specify what simulator to use (e.g., verilator, modelsim, icarus)
+    simulator = "verilator"
+
+    # Specify build directory
+    sim_build = tests_path + "/test/sim_build/{}/".format(toplevel)
+
+    run(
+        verilog_sources=rtl_sources,
+        includes=include_folders,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        sim_build=sim_build,
+        parameters=parameters
+    )

--- a/tests/tb/tb_shift_reg.sv
+++ b/tests/tb/tb_shift_reg.sv
@@ -1,34 +1,31 @@
 //---------------------------------
 // Copyright 2023 KULeuven
 // Author: Ryan Antonio (ryan.antonio@esat.kuleuven.be)
+//
+// Description:
+//
+// This wrapper is necessary, since cocotb can not resolve user-defined
+// typedefs attached to the DUT directly. 
+//
+// The testbench contains parameters that can be controlled
+// directly from cocotb.
 //---------------------------------
 
 module tb_shift_reg #(
-
-    //---------------------------------
-    // Soft parameters that can change from cocotb pytest
-    //---------------------------------
     parameter int unsigned DataWidth = 8,
     parameter int unsigned Depth     = 1
-
 );
 
     //---------------------------------
-    // Hard parameters that cannot be changed from cocotb pytest
+    // Workaround for cocotb to access the user defined dtype
     //---------------------------------
     localparam type dtype = logic [DataWidth-1:0];
 
-    //---------------------------------
-    // Wires
-    //---------------------------------
     logic clk_i;
     logic rst_ni;
     dtype d_i;
     dtype d_o;
 
-    //---------------------------------
-    // Main DUT
-    //---------------------------------
     shift_reg #(
         .dtype  ( dtype  ),
         .Depth  ( Depth  )

--- a/tests/tb/tb_shift_reg.sv
+++ b/tests/tb/tb_shift_reg.sv
@@ -1,0 +1,43 @@
+//---------------------------------
+// Copyright 2023 KULeuven
+// Author: Ryan Antonio (ryan.antonio@esat.kuleuven.be)
+//---------------------------------
+
+module tb_shift_reg #(
+
+    //---------------------------------
+    // Soft parameters that can change from cocotb pytest
+    //---------------------------------
+    parameter int unsigned DataWidth = 8,
+    parameter int unsigned Depth     = 1
+
+);
+
+    //---------------------------------
+    // Hard parameters that cannot be changed from cocotb pytest
+    //---------------------------------
+    localparam type dtype = logic [DataWidth-1:0];
+
+    //---------------------------------
+    // Wires
+    //---------------------------------
+    logic clk_i;
+    logic rst_ni;
+    dtype d_i;
+    dtype d_o;
+
+    //---------------------------------
+    // Main DUT
+    //---------------------------------
+    shift_reg #(
+        .dtype  ( dtype  ),
+        .Depth  ( Depth  )
+    ) i_shift_reg (
+        .clk_i  ( clk_i  ),  
+        .rst_ni ( rst_ni ),   
+        .d_i    ( d_i    ),
+        .d_o    ( d_o    )
+    );
+
+
+endmodule

--- a/tests/tb/tb_shift_reg.sv
+++ b/tests/tb/tb_shift_reg.sv
@@ -33,11 +33,10 @@ module tb_shift_reg #(
         .dtype  ( dtype  ),
         .Depth  ( Depth  )
     ) i_shift_reg (
-        .clk_i  ( clk_i  ),  
-        .rst_ni ( rst_ni ),   
+        .clk_i  ( clk_i  ),
+        .rst_ni ( rst_ni ),
         .d_i    ( d_i    ),
         .d_o    ( d_o    )
     );
-
 
 endmodule


### PR DESCRIPTION
This PR shows an initial test on how to import PULP IPs and test them.

There are key notes in here:

- Whenever we do a bender pull, it appends a hash to the package directories that can differ in different PCs. Hence the path names can change for every CI run.
  - To fix we need to run bender before the tests in CI to do a pull
  - Then we need to ensure that the tests extract the correct "benderized" path by executing `bender path <insert_package_name>` using a subprocess and PIPE the stdout. The result returns the appropriate path to the given package.
 
- Cocotb's signal tree (the graph or tree of signals that can be seen in an RTL design) fails to see user defined type definitions. For example, in the shift_reg.sv module, the `dtype` definition cannot be seen by cocotb. Hence we need to re-define or re-map some of these signals, parameters, buses, and so on.
  - The working solution was to create a separate test bench and define some of these signals inside.
  - It is a horrible limitation... however cocotb will still be useful for elegantly testing features.
 