### PR TITLE
Update docker to include Bender

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -12,7 +12,7 @@ RUN autoconf && ./configure && make -j `nproc`
 RUN make test
 ENV PATH="$VERILATOR_ROOT/bin:$PATH"
 
-# Build Rust tools for bender
+# Get bender binary
 WORKDIR /tools/bender/bin
 RUN curl --proto '=https' --tlsv1.2 https://pulp-platform.github.io/bender/init -sSf | sh
 ENV PATH "/tools/bender/bin:${PATH}"

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -13,13 +13,9 @@ RUN make test
 ENV PATH="$VERILATOR_ROOT/bin:$PATH"
 
 # Build Rust tools for bender
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH "/root/.cargo/bin:${PATH}"
-RUN rustup install 1.63.0
-RUN rustup override set 1.63.0
-
-# Install Bender
-RUN cargo install bender --version 0.23.2
+WORKDIR /tools/bender/bin
+RUN curl --proto '=https' --tlsv1.2 https://pulp-platform.github.io/bender/init -sSf | sh
+ENV PATH "/tools/bender/bin:${PATH}"
 
 # Install python dependencies
 WORKDIR /repo

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # Install verilator dependencies and python for cocotb and pytest
-RUN apt-get update && apt-get -y install git autoconf help2man perl python3 python3-pip make flex bison g++ libfl2 libfl-dev
+RUN apt-get update && apt-get -y install git autoconf help2man perl python3 python3-pip make flex bison g++ libfl2 libfl-dev curl
 
 # Cocotb explicitly requires verilator v5.006, so compile from source
 RUN git clone https://github.com/verilator/verilator
@@ -11,6 +11,15 @@ ENV VERILATOR_ROOT=/verilator
 RUN autoconf && ./configure && make -j `nproc`
 RUN make test
 ENV PATH="$VERILATOR_ROOT/bin:$PATH"
+
+# Build Rust tools for bender
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH "/root/.cargo/bin:${PATH}"
+RUN rustup install 1.63.0
+RUN rustup override set 1.63.0
+
+# Install Bender
+RUN cargo install bender --version 0.23.2
 
 # Install python dependencies
 WORKDIR /repo

--- a/util/container/requirements.txt
+++ b/util/container/requirements.txt
@@ -1,3 +1,0 @@
-cocotb==1.8.0
-cocotb-test==0.2.4
-pytest==7.4.0


### PR DESCRIPTION
This PR simply updates the docker to include the Bender installation. 

Also remove the duplicate requirements.txt found under the `util/container` directory.