### PR TITLE
Create a generic template generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Generate streamer SV template
         run: |
-        util/scripts/template_gen.py \
+        python3 util/scripts/template_gen.py \
         --cfg_path="./util/cfg/streamer_cfg.hjson" \
         --tpl_path="./util/templates/streamer.sv.tpl" \
         --out_path="./rtl/streamer_wrapper.sv"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,19 @@ jobs:
         run: |
           pytest -v -o log_cli=True
 
+jobs:
+  tpl-test-gen:
+    name: Template generation test
+    runs-on: ubuntu-22.04
+    container:
+      image: rgantonio/snax-cocotb
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate streamer SV template
+        run: |
+        util/scripts/template_gen.py \
+        --cfg_path="./util/cfg/streamer_cfg.hjson" \
+        --tpl_path="./util/templates/streamer.sv.tpl" \
+        --out_path="./rtl/streamer_wrapper.sv"
   
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         run: |
           pytest -v -o log_cli=True
 
-jobs:
   tpl-test-gen:
     name: Template generation test
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Generate streamer SV template
         run: |
-        python3 util/scripts/template_gen.py \
-        --cfg_path="./util/cfg/streamer_cfg.hjson" \
-        --tpl_path="./util/templates/streamer.sv.tpl" \
-        --out_path="./rtl/streamer_wrapper.sv"
+          python3 util/scripts/template_gen.py \
+          --cfg_path="./util/cfg/streamer_cfg.hjson" \
+          --tpl_path="./util/templates/streamer.sv.tpl" \
+          --out_path="./rtl/streamer_wrapper.sv"
   
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ cocotb==1.8.0
 cocotb-test==0.2.4
 pytest==7.4.0
 mako==1.3.0
+jsonref==1.1.0
+hjson==3.1.0
 pre-commit
 ruff
 black

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cocotb==1.8.0
 cocotb-test==0.2.4
 pytest==7.4.0
+mako==1.3.0
 pre-commit
 ruff
 black

--- a/util/cfg/streamer_cfg.hjson
+++ b/util/cfg/streamer_cfg.hjson
@@ -2,18 +2,41 @@
 {
     // These handle the fifo data width
     // and fifo data depth
-    fifoWidthReader: [64,64,64],
-    fifoDepthReader: [2, 2, 2],
-    fifoWidthWriter: [64],
-    fifoDepthWriter: [2],
+    temporalAddrGenUnitParams: {
+      loopDim: 1,
+      loopBoundWidth: 8,
+      addrWidth: 15
+    }
 
-    // TCDM port handling
-    dataReaderNum: 3,
-    dataWriterNum: 1,
-    dataReaderTcdmPorts: [1,1,1],
-    dataWriterTcdmPorts: [1],
-    readElementWidth: [32, 32, 32],
-    writeElementWidth: [32],
+    fifoReaderParams: {
+      fifoWidth: [256,256,256],
+      fifoDepth: [2, 2, 2],
+    }
+
+    fifoWriterParams: {
+      fifoWidth: [64],
+      fifoDepth: [2],
+    }
+
+    dataReaderParams:{
+      tcdmPortsNum: [4,4,1],
+      spatialBounds: [[8],[8],[8]],
+      unrollingDim: [2,2,2],
+      spatialDim: [1,1,1],
+      elementWidth: [32,32,32],
+      fifoWidth: [64,64,64]
+    }
+
+    dataWriterParams:{
+      tcdmPortsNum: [1],
+      spatialBounds: [[2]],
+      spatialDim: [1],
+      elementWidth: [32],
+      fifoWidth: [64]
+    }
+
+    // Stationarity
+    stationarity: [0,0,1,1]
 
     // TCDM data and address bit widths
     tcdmDataWidth: 64,
@@ -22,13 +45,4 @@
     numBanks: 8,
     numInputs: 2,
     numOutputs: 4
-
-    // Unrolling factors
-    unrollingFactorReader: [[2],[2],[2]],
-    unrollingFactorWriter: [[2]],
-    temporalLoopDim: 1,
-    temporalLoopBoundWidth: 8,
-
-    // Stationarity
-    stationarity: [0,0,1,1]
 }

--- a/util/cfg/streamer_cfg.hjson
+++ b/util/cfg/streamer_cfg.hjson
@@ -1,0 +1,34 @@
+// Streamer configuration file
+{
+    // These handle the fifo data width
+    // and fifo data depth
+    fifoWidthReader: [64,64,64],
+    fifoDepthReader: [2, 2, 2],
+    fifoWidthWriter: [64],
+    fifoDepthWriter: [2],
+
+    // TCDM port handling
+    dataReaderNum: 3,
+    dataWriterNum: 1,
+    dataReaderTcdmPorts: [1,1,1],
+    dataWriterTcdmPorts: [1],
+    readElementWidth: [32, 32, 32],
+    writeElementWidth: [32],
+
+    // TCDM data and address bit widths
+    tcdmDataWidth: 64,
+    addrWidth: 48,
+    tcdmDepth: 256,
+    numBanks: 8,
+    numInputs: 2,
+    numOutputs: 4
+
+    // Unrolling factors
+    unrollingFactorReader: [[2],[2],[2]],
+    unrollingFactorWriter: [[2]],
+    temporalLoopDim: 1,
+    temporalLoopBoundWidth: 8,
+
+    // Stationarity
+    stationarity: [0,0,1,1]
+}

--- a/util/scripts/template_gen.py
+++ b/util/scripts/template_gen.py
@@ -5,8 +5,9 @@ from typing import Union, List, Dict
 import hjson
 import argparse
 
+
 # Extract json file
-def get_config (cfg_path: str):
+def get_config(cfg_path: str):
     with open(cfg_path, "r") as jsonf:
         srcfull = jsonf.read()
 
@@ -15,25 +16,39 @@ def get_config (cfg_path: str):
     cfg = JsonRef.replace_refs(cfg)
     return cfg
 
+
 # Read template
-def get_template (tpl_path: str) -> Template:
+def get_template(tpl_path: str) -> Template:
     tpl_list = TemplateLookup(directories=["."], output_encoding="utf-8")
     tpl = tpl_list.get_template(tpl_path)
     return tpl
 
+
 # Generate file
-def gen_file (cfg, tpl, target_path: str) -> None:
+def gen_file(cfg, tpl, target_path: str) -> None:
     with open(target_path, "w") as f:
         f.write(str(tpl.render_unicode(cfg=cfg)))
     return
 
+
 # Main function run and parsing
 def main():
     # Parse all arguments
-    parser = argparse.ArgumentParser(description='Wrapper generator for any file. Inputs are simply the template and configuration files.')
-    parser.add_argument('--cfg_path', type=str, default='./', help='Points to the configuration file path')
-    parser.add_argument('--tpl_path', type=str, default='./', help='Points to the template file path')
-    parser.add_argument('--out_path', type=str, default='./', help='Points to the output directory')
+    parser = argparse.ArgumentParser(
+        description="Wrapper generator for any file. Inputs are simply the template and configuration files."
+    )
+    parser.add_argument(
+        "--cfg_path",
+        type=str,
+        default="./",
+        help="Points to the configuration file path",
+    )
+    parser.add_argument(
+        "--tpl_path", type=str, default="./", help="Points to the template file path"
+    )
+    parser.add_argument(
+        "--out_path", type=str, default="./", help="Points to the output directory"
+    )
 
     # Get the list of parsing
     args = parser.parse_args()
@@ -42,6 +57,7 @@ def main():
     cfg = get_config(args.cfg_path)
     tpl = get_template(args.tpl_path)
     gen_file(cfg=cfg, tpl=tpl, target_path=args.out_path)
+
 
 if __name__ == "__main__":
     main()

--- a/util/scripts/template_gen.py
+++ b/util/scripts/template_gen.py
@@ -1,0 +1,47 @@
+from mako.lookup import TemplateLookup
+from mako.template import Template
+from jsonref import JsonRef
+from typing import Union, List, Dict
+import hjson
+import argparse
+
+# Extract json file
+def get_config (cfg_path: str):
+    with open(cfg_path, "r") as jsonf:
+        srcfull = jsonf.read()
+
+    # Format hjson file
+    cfg = hjson.loads(srcfull, use_decimal=True)
+    cfg = JsonRef.replace_refs(cfg)
+    return cfg
+
+# Read template
+def get_template (tpl_path: str) -> Template:
+    tpl_list = TemplateLookup(directories=["."], output_encoding="utf-8")
+    tpl = tpl_list.get_template(tpl_path)
+    return tpl
+
+# Generate file
+def gen_file (cfg, tpl, target_path: str) -> None:
+    with open(target_path, "w") as f:
+        f.write(str(tpl.render_unicode(cfg=cfg)))
+    return
+
+# Main function run and parsing
+def main():
+    # Parse all arguments
+    parser = argparse.ArgumentParser(description='Wrapper generator for any file. Inputs are simply the template and configuration files.')
+    parser.add_argument('--cfg_path', type=str, default='./', help='Points to the configuration file path')
+    parser.add_argument('--tpl_path', type=str, default='./', help='Points to the template file path')
+    parser.add_argument('--out_path', type=str, default='./', help='Points to the output directory')
+
+    # Get the list of parsing
+    args = parser.parse_args()
+
+    # Grab config and template then generate the combination of two
+    cfg = get_config(args.cfg_path)
+    tpl = get_template(args.tpl_path)
+    gen_file(cfg=cfg, tpl=tpl, target_path=args.out_path)
+
+if __name__ == "__main__":
+    main()

--- a/util/scripts/template_gen.py
+++ b/util/scripts/template_gen.py
@@ -1,7 +1,6 @@
 from mako.lookup import TemplateLookup
 from mako.template import Template
 from jsonref import JsonRef
-from typing import Union, List, Dict
 import hjson
 import argparse
 
@@ -35,7 +34,8 @@ def gen_file(cfg, tpl, target_path: str) -> None:
 def main():
     # Parse all arguments
     parser = argparse.ArgumentParser(
-        description="Wrapper generator for any file. Inputs are simply the template and configuration files."
+        description="Wrapper generator for any file. \
+            Inputs are simply the template and configuration files."
     )
     parser.add_argument(
         "--cfg_path",

--- a/util/templates/streamParam.scala.tpl
+++ b/util/templates/streamParam.scala.tpl
@@ -1,0 +1,86 @@
+<%def name="list_elem(prop)">\
+  % for c in cfg[prop]:
+${c}${', ' if not loop.last else ''}\
+  % endfor
+</%def>\
+package streamer
+
+import chisel3._
+import chisel3.util._
+
+/** Parameter definitions fifoWidthReader - FIFO width for the data readers
+  * fifoDepthReader - FIFO depth for the data readers fifoWidthWriter - FIFO
+  * width for the data writers fifoDepthWriter - FIFO depth for the data writers
+  * dataReaderNum - number of data readers dataWriterNum - number of data
+  * writers dataReaderTcdmPorts - the number of connections to TCDM ports for
+  * each data reader dataWriterTcdmPorts - the number of connections to TCDM
+  * ports for each data writer readElementWidth - single data element width for
+  * each data reader, useful for generating unrolling addresses
+  * writeElementWidth - single data element width for each data writer, useful
+  * for generating unrolling addresses tcdmDataWidth - data width for each TCDm
+  * port unrollingFactorReader - spatial unrolling factors (your parfor) for
+  * each data reader unrollingFactorWriter - spatial unrolling factors (your
+  * parfor) for each data writer temporalLoopDim - the dimension of the temporal
+  * loop temporalLoopBoundWidth - the register width for storing the temporal
+  * loop bound addrWidth - the address width stationarity - accelerator
+  * stationarity feature for each data mover (data reader and data writer)
+  */
+
+// Streamer parameters
+object StreamerParameters {
+  def fifoWidthReader = Seq(${list_elem('fifoWidthWriter')})
+  def fifoDepthReader = Seq(${list_elem('fifoWidthReader')})
+
+  def fifoWidthWriter = ${list_elem('fifoWidthWriter')}
+  def fifoDepthWriter = ${list_elem('fifoDepthWriter')}
+
+  def dataReaderNum = ${cfg["dataReaderNum"]}
+  def dataWriterNum = ${cfg["dataWriterNum"]}
+  def dataReaderTcdmPorts = Seq(${list_elem('dataReaderTcdmPorts')})
+  def dataWriterTcdmPorts = Seq(${list_elem('dataWriterTcdmPorts')})
+  def readElementWidth = Seq(${list_elem('readElementWidth')})
+  def writeElementWidth = Seq(${list_elem('writeElementWidth')})
+
+  def tcdmDataWidth = ${cfg["tcdmDataWidth"]}
+
+  def unrollingFactorReader = Seq(\
+% for c in cfg["unrollingFactorReader"]:
+Seq(\
+  % for d in c:
+${d}${', ' if not loop.last else ''}\
+  % endfor
+)${', ' if not loop.last else ''}\
+% endfor
+)
+  def unrollingFactorWriter = Seq(\
+% for c in cfg["unrollingFactorWriter"]:
+Seq(\
+  % for d in c:
+${d}${', ' if not loop.last else ''}\
+  % endfor
+)${', ' if not loop.last else ''}\
+% endfor
+)
+
+  def temporalLoopDim = ${cfg["temporalLoopDim"]}
+  def temporalLoopBoundWidth = ${cfg["temporalLoopBoundWidth"]}
+
+  def addrWidth = ${cfg["addrWidth"]}
+
+  def stationarity = Seq(${list_elem('stationarity')})
+
+  // inferenced parameters
+  def dataMoverNum = dataReaderNum + dataWriterNum
+  def tcdmPortsNum = dataReaderTcdmPorts.sum + dataWriterTcdmPorts.sum
+  def unrollingDimReader = (0 until unrollingFactorReader.length).map(i =>
+    unrollingFactorReader(i).length
+  )
+  def unrollingDimWriter = (0 until unrollingFactorWriter.length).map(i =>
+    unrollingFactorWriter(i).length
+  )
+  def unrollingDim: Seq[Int] = (0 until unrollingFactorReader.length).map(i =>
+    unrollingFactorReader(i).length
+  ) ++ (0 until unrollingFactorWriter.length).map(i =>
+    unrollingFactorWriter(i).length
+  )
+}

--- a/util/templates/streamer.sv.tpl
+++ b/util/templates/streamer.sv.tpl
@@ -1,0 +1,142 @@
+//-----------------------------
+// Streamer wrapper
+//-----------------------------
+
+module streamer_wrapper #(
+  parameter int unsigned NarrowDataWidth = ${cfg["tcdmDataWidth"]},
+  parameter int unsigned TCDMDepth = ${cfg["tcdmDepth"]},
+  parameter int unsigned NrBanks = ${cfg["numBanks"]},
+  parameter int unsigned NumInp = ${cfg["numInputs"]},
+  parameter int unsigned NumOut = ${cfg["numOutputs"]},
+  parameter int unsigned TCDMMemAddrWidth = $clog2(TCDMDepth),
+  parameter int unsigned TCDMSize = NrBanks * TCDMDepth * (NarrowDataWidth/8),
+  parameter int unsigned TCDMAddrWidth = $clog2(TCDMSize)
+)(
+
+  //-----------------------------
+  // Clocks and reset
+  //-----------------------------
+  input logic clk_i,
+  input logic rst_ni,
+
+  //-----------------------------
+  // Accelerator ports
+  //-----------------------------
+  // Output ports from streamer to accelerator
+% for idx, dw in enumerate(cfg['fifoWidthWriter']):
+  input logic [${dw-1}:0] acc2stream_data_${idx}_bits_i,
+  input logic acc2stream_data_${idx}_valid_i,
+  output logic acc2stream_data_${idx}_ready_o,
+
+% endfor
+  // Input ports from acclerator to streamer
+% for idx, dw in enumerate(cfg['fifoWidthReader']):
+  output logic [${dw-1}:0] stream2acc_data_${idx + len(cfg['fifoWidthWriter'])}_bits_o,
+  output logic stream2acc_data_${idx + len(cfg['fifoWidthWriter'])}_valid_o,
+  input logic stream2acc_data_${idx + len(cfg['fifoWidthWriter'])}_ready_i,
+
+% endfor
+  //-----------------------------
+  // TCDM ports
+  //-----------------------------
+  // Request
+  output logic [NumOut-1:0] tcdm_req_write_o,
+  output logic [NumOut-1:0][TCDMAddrWidth-1:0] tcdm_req_addr_o,
+  output logic [NumOut-1:0][3:0] tcdm_req_amo_o, //Note that tcdm_req_amo_i is 4 bits based on reqrsp definition
+  output logic [NumOut-1:0][NarrowDataWidth-1:0] tcdm_req_data_o,
+  output logic [NumOut-1:0][4:0] tcdm_req_user_core_id_o, //Note that tcdm_req_user_core_id_i is 5 bits based on Snitch definition
+  output logic [NumOut-1:0] tcdm_req_user_is_core_o,
+  output logic [NumOut-1:0][NarrowDataWidth/8-1:0] tcdm_req_strb_o,
+  output logic [NumOut-1:0] tcdm_req_q_valid_o,
+
+  // Response
+  input logic [NumOut-1:0] tcdm_rsp_q_ready_i,
+  input logic [NumOut-1:0] tcdm_rsp_p_valid_i,
+  input logic [NumOut-1:0][NarrowDataWidth-1:0] tcdm_rsp_data_i,
+
+  //-----------------------------
+  // CSR control ports
+  //-----------------------------
+  // Request
+  input logic [31:0] io_csr_req_bits_data_i,
+  input logic io_csr_req_bits_addr_i,
+  input logic io_csr_req_bits_write_i,
+  input logic io_csr_req_valid_i,
+  output logic io_csr_req_ready_o,
+
+  // Response
+  input logic io_csr_rsp_ready_i,
+  output logic io_csr_rsp_valid_o,
+  output logic [31:0] io_csr_rsp_bits_data_o
+);
+
+  // Fixed ports that are defaulted
+  // towards the TCDM from the streamer
+  always_comb begin
+    for(int i = 0; i < NumOut; i++ ) begin
+      tcdm_req_amo_o[i] = '0;
+      tcdm_req_user_core_id_o[i] = '0;
+      tcdm_req_user_is_core_o[i] = '0;
+      tcdm_req_strb_o[i] = '1;
+    end
+  end
+
+  // Streamer module that is generated
+  // with template mechanics
+  Streamer(	
+    //-----------------------------
+    // Clocks and reset
+    //-----------------------------
+    .clock ( clk_i   ),
+    .reset ( ~rst_ni ),
+
+    //-----------------------------
+    // Accelerator ports
+    //-----------------------------
+% for idx, dw in enumerate(cfg['fifoWidthWriter']):
+    .io_accelerator2streamer_data_${idx}_bits ( acc2stream_data_${idx}_bits_i ),
+    .io_accelerator2streamer_data_${idx}_valid ( acc2stream_data_${idx}_valid_i ),
+    .io_accelerator2streamer_data_${idx}_ready ( acc2stream_data_${idx}_ready_o ),
+
+% endfor
+% for idx, dw in enumerate(cfg['fifoWidthReader']):
+    .io_streamer2accelerator_data_${idx + len(cfg['fifoWidthWriter'])}_bits ( stream2acc_data_${idx + len(cfg['fifoWidthWriter'])}_bits_i ),
+    .io_streamer2accelerator_data_${idx + len(cfg['fifoWidthWriter'])}_valid ( stream2acc_data_${idx + len(cfg['fifoWidthWriter'])}_valid_i ),
+    .io_streamer2accelerator_data_${idx + len(cfg['fifoWidthWriter'])}_ready ( stream2acc_data_${idx + len(cfg['fifoWidthWriter'])}_ready_o ),
+
+% endfor
+    //-----------------------------
+    // TCDM Ports
+    //-----------------------------
+    // Request
+% for idx in range(0, cfg["numOutputs"]):
+    .io_tcdm_rsp_${idx}_bits_data ( tcdm_rsp_data_i[${idx}] ),
+    .io_tcdm_rsp_${idx}_valid ( tcdm_rsp_p_valid_i[${idx}] ),
+    .io_tcdm_req_${idx}_ready ( tcdm_rsp_q_ready_i[${idx}] ),
+
+% endfor
+    // Response
+% for idx in range(0, cfg["numOutputs"]):
+    .io_tcdm_req_${idx}_valid ( tcdm_req_q_valid_o[${idx}] ),
+    .io_tcdm_req_${idx}_bits_addr ( tcdm_req_addr_o[${idx}] ),
+    .io_tcdm_req_${idx}_bits_write ( tcdm_req_write_o[${idx}] ),
+    .io_tcdm_req_${idx}_bits_data ( tcdm_req_data_o[${idx}] ),
+
+% endfor
+    //-----------------------------
+    // CSR control ports
+    //-----------------------------
+    // Request
+    .io_csr_req_bits_data ( io_csr_req_bits_data_i ),
+    .io_csr_req_bits_addr ( io_csr_req_bits_addr_i ),
+    .io_csr_req_bits_write ( io_csr_req_bits_write_i ),
+    .io_csr_req_valid ( io_csr_req_valid_i ),
+    .io_csr_req_ready ( io_csr_req_ready_o ),
+
+    // Response
+    .io_csr_rsp_bits_data ( io_csr_rsp_bits_data_o ),	
+    .io_csr_rsp_valid ( io_csr_rsp_ready_i ),
+    .io_csr_rsp_ready ( io_csr_rsp_valid_o )
+  );
+
+endmodule


### PR DESCRIPTION
This PR adds a template generator wherein you grab a configuration file (`.hjson`) and a mako template (`.tpl`).

Users can create their config-template combination and use the Python script `template_gen.py` to map the configurations from the config file to the template of interest.

This PR includes:
* 2 configuration files for the streamer wrapper (which will be used later) and for the streamer parameters that Chisel will use.
* 2 template files for the streamer wrapper and the streamer parameters.
* `template_gen.py` is the template generator that grabs the configuration and template files.

BIG NOTE: Is there a test? NO. We will add the test later along with @xiaoling-yi's streamer.
Think about it, would you like to review gazillions of lines? :> hahaha