### PR TITLE
Add DMA to TCDM subsystem test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
           bender script flist
       - name: Running Pytest
         run: |
-          pytest -v -o log_cli=True
+          pytest

--- a/rtl/memory-subsys/tcdm_subsys.sv
+++ b/rtl/memory-subsys/tcdm_subsys.sv
@@ -156,20 +156,20 @@ module tcdm_subsys #(
   always_comb begin
 
     // These signals are never used
-    tcdm_dma_req.q.amo   = reqrsp_pkg::AMONone;
-    tcdm_dma_req.q.user = '0;
+    tcdm_dma_req.q.amo     = reqrsp_pkg::AMONone;
+    tcdm_dma_req.q.user    = '0;
 
     // Remapping for visibility
     // Request (incoming) remapping
-    tcdm_dma_req.q.write  = tcdm_dma_req_write_i;
-    tcdm_dma_req.q.addr   = tcdm_dma_req_addr_i;
-    tcdm_dma_req.q.data   = tcdm_dma_req_data_i;
-    tcdm_dma_req.q.strb   = tcdm_dma_req_strb_i;
-    tcdm_dma_req.q_valid  = tcdm_dma_req_q_valid_i;
+    tcdm_dma_req.q.write   = tcdm_dma_req_write_i;
+    tcdm_dma_req.q.addr    = tcdm_dma_req_addr_i;
+    tcdm_dma_req.q.data    = tcdm_dma_req_data_i;
+    tcdm_dma_req.q.strb    = tcdm_dma_req_strb_i;
+    tcdm_dma_req.q_valid   = tcdm_dma_req_q_valid_i;
 
     // Response (outgoing) remapping
     tcdm_dma_rsp_q_ready_o = tcdm_dma_rsp.q_ready;
-    tcdm_dma_rsp_p_valid_o     = tcdm_dma_rsp.p_valid;
+    tcdm_dma_rsp_p_valid_o = tcdm_dma_rsp.p_valid;
     tcdm_dma_rsp_data_o    = tcdm_dma_rsp.p.data;
   end
 

--- a/rtl/memory-subsys/tcdm_subsys.sv
+++ b/rtl/memory-subsys/tcdm_subsys.sv
@@ -17,22 +17,27 @@
 // TCDMSize - total size of TCDM memory
 // TCDMAddrWidth - total address width of memory
 // NumInp - number of requesters (core or accelerator)
-// NumOut - number of ports connected to memory
-//        - this one should actually be equal to NrBanks
 //-----------------------------------
 
 module tcdm_subsys #(
   parameter int unsigned NarrowDataWidth  = 64,
   parameter int unsigned TCDMDepth        = 512,
   parameter int unsigned NrBanks          = 32,
+  parameter int unsigned WideDataWidth    = 512, // Need to set wide data width to max bits of banks
   parameter int unsigned TCDMMemAddrWidth = $clog2(TCDMDepth),
   parameter int unsigned TCDMSize         = NrBanks * TCDMDepth * (NarrowDataWidth/8),
   parameter int unsigned TCDMAddrWidth    = $clog2(TCDMSize),
-  parameter int unsigned NumInp           = 2,
-  parameter int unsigned NumOut           = 2
+  parameter int unsigned NumInp           = 2
 )(
-  input  logic                                      clk_i,
-  input  logic                                      rst_ni,
+  //-----------------------------
+  // Clocks and Reset
+  //-----------------------------
+  input  logic  clk_i,
+  input  logic  rst_ni,
+
+  //-----------------------------
+  // TCDM ports
+  //-----------------------------
   input  logic  [NumInp-1:0]                        tcdm_req_write_i,
   input  logic  [NumInp-1:0][TCDMAddrWidth-1:0]     tcdm_req_addr_i,
   //Note that tcdm_req_amo_i is 4 bits based on reqrsp definition
@@ -45,11 +50,28 @@ module tcdm_subsys #(
   input  logic  [NumInp-1:0]                        tcdm_req_q_valid_i,
   output logic  [NumInp-1:0]                        tcdm_rsp_q_ready_o,
   output logic  [NumInp-1:0]                        tcdm_rsp_p_valid_o,
-  output logic  [NumInp-1:0][NarrowDataWidth-1:0]   tcdm_rsp_data_o
+  output logic  [NumInp-1:0][NarrowDataWidth-1:0]   tcdm_rsp_data_o,
+
+  //-----------------------------
+  // Wide TCDM ports
+  //-----------------------------
+  input  logic                        tcdm_dma_req_write_i,
+  input  logic  [  TCDMAddrWidth-1:0] tcdm_dma_req_addr_i,
+  input  logic  [  WideDataWidth-1:0] tcdm_dma_req_data_i,
+  input  logic  [WideDataWidth/8-1:0] tcdm_dma_req_strb_i,
+  input  logic                        tcdm_dma_req_q_valid_i,
+  output logic                        tcdm_dma_rsp_q_ready_o,
+  output logic                        tcdm_dma_rsp_p_valid_o,
+  output logic  [  WideDataWidth-1:0] tcdm_dma_rsp_data_o
 );
 
+  localparam int unsigned BanksPerSuperBank = WideDataWidth/NarrowDataWidth;
+  localparam int unsigned NrSuperBanks      = NrBanks/BanksPerSuperBank;
+
   typedef logic [  NarrowDataWidth-1:0] data_t;
+  typedef logic [    WideDataWidth-1:0] data_dma_t;
   typedef logic [NarrowDataWidth/8-1:0] strb_t;
+  typedef logic [  WideDataWidth/8-1:0] strb_dma_t;
   typedef logic [    TCDMAddrWidth-1:0] tcdm_addr_t;
   typedef logic [ TCDMMemAddrWidth-1:0] tcdm_mem_addr_t;
 
@@ -73,12 +95,22 @@ module tcdm_subsys #(
   `TCDM_TYPEDEF_ALL (tcdm, tcdm_addr_t, data_t, strb_t, tcdm_user_t)
   `MEM_TYPEDEF_ALL (mem, tcdm_mem_addr_t, data_t, strb_t, tcdm_user_t)
 
-  // Main connections
+  `TCDM_TYPEDEF_ALL(tcdm_dma, tcdm_addr_t, data_dma_t, strb_dma_t, logic)
+  `MEM_TYPEDEF_ALL (mem_dma, tcdm_mem_addr_t, data_dma_t, strb_dma_t, logic)
+
+  // Main connections for narrow TCDM
   tcdm_req_t [NumInp-1:0] tcdm_req;
   tcdm_rsp_t [NumInp-1:0] tcdm_rsp;
 
-  mem_req_t  [NumOut-1:0] mem_req;
-  mem_rsp_t  [NumOut-1:0] mem_rsp;
+  mem_req_t [NrSuperBanks-1:0][BanksPerSuperBank-1:0] narrow_req;
+  mem_rsp_t [NrSuperBanks-1:0][BanksPerSuperBank-1:0] narrow_rsp;
+
+  // Main connections for wide TCDM
+  tcdm_dma_req_t tcdm_dma_req;
+  tcdm_dma_rsp_t tcdm_dma_rsp;
+
+  mem_dma_req_t [NrSuperBanks-1:0] wide_dma_req;
+  mem_dma_rsp_t [NrSuperBanks-1:0] wide_dma_rsp;
 
   // Hard re-mapping of TCDM req and rsp
   // To make the control ports more generic
@@ -121,9 +153,29 @@ module tcdm_subsys #(
     end
   end
 
+  always_comb begin
+
+    // These signals are never used
+    tcdm_dma_req.q.amo   = reqrsp_pkg::AMONone;
+    tcdm_dma_req.q.user = '0;
+
+    // Remapping for visibility
+    // Request (incoming) remapping
+    tcdm_dma_req.q.write  = tcdm_dma_req_write_i;
+    tcdm_dma_req.q.addr   = tcdm_dma_req_addr_i;
+    tcdm_dma_req.q.data   = tcdm_dma_req_data_i;
+    tcdm_dma_req.q.strb   = tcdm_dma_req_strb_i;
+    tcdm_dma_req.q_valid  = tcdm_dma_req_q_valid_i;
+
+    // Response (outgoing) remapping
+    tcdm_dma_rsp_q_ready_o = tcdm_dma_rsp.q_ready;
+    tcdm_dma_rsp_p_valid_o     = tcdm_dma_rsp.p_valid;
+    tcdm_dma_rsp_data_o    = tcdm_dma_rsp.p.data;
+  end
+
   snitch_tcdm_interconnect #(
     .NumInp                ( NumInp                              ),
-    .NumOut                ( NumOut                              ),
+    .NumOut                ( NrBanks                             ),
     .tcdm_req_t            ( tcdm_req_t                          ),
     .tcdm_rsp_t            ( tcdm_rsp_t                          ),
     .mem_req_t             ( mem_req_t                           ),
@@ -139,81 +191,129 @@ module tcdm_subsys #(
     .rst_ni                ( rst_ni                              ),
     .req_i                 ( tcdm_req                            ),
     .rsp_o                 ( tcdm_rsp                            ),
-    .mem_req_o             ( mem_req                             ),
-    .mem_rsp_i             ( mem_rsp                             )
+    .mem_req_o             ( narrow_req                          ),
+    .mem_rsp_i             ( narrow_rsp                          )
   );
 
-  // Generate multi-bank memories
-  // Number of banks matches number of memories
-  for (genvar i = 0; i < NumOut; i++) begin : gen_tcdm_bank
+  snitch_tcdm_interconnect #(
+    .NumInp                ( 1                                   ),
+    .NumOut                ( NrSuperBanks                        ),
+    .tcdm_req_t            ( tcdm_dma_req_t                      ),
+    .tcdm_rsp_t            ( tcdm_dma_rsp_t                      ),
+    .mem_req_t             ( mem_dma_req_t                       ),
+    .mem_rsp_t             ( mem_dma_rsp_t                       ),
+    .MemAddrWidth          ( TCDMMemAddrWidth                    ),
+    .DataWidth             ( WideDataWidth                       ),
+    .user_t                ( logic                               ),
+    .MemoryResponseLatency ( 1                                   ),
+    .Radix                 ( 2                                   ),
+    .Topology              ( snitch_pkg::LogarithmicInterconnect )
+  ) i_dma_tcdm_interconnect (
+    .clk_i                 ( clk_i                               ),
+    .rst_ni                ( rst_ni                              ),
+    .req_i                 ( tcdm_dma_req                        ),
+    .rsp_o                 ( tcdm_dma_rsp                        ),
+    .mem_req_o             ( wide_dma_req                        ),
+    .mem_rsp_i             ( wide_dma_rsp                        )
+  );
 
-    logic           mem_cs;
-    logic           mem_wen;
-    tcdm_mem_addr_t mem_add;
-    strb_t          mem_be;
-    data_t          mem_rdata;
-    data_t          mem_wdata;
-    data_t          amo_rdata_local;
 
-    tc_sram_impl #(
-      .NumWords   ( TCDMDepth       ),
-      .DataWidth  ( NarrowDataWidth ),
-      .ByteWidth  ( 8               ),
-      .NumPorts   ( 1               ),
-      .SimInit    ( "zeros"         ),
-      .Latency    ( 1               ),
-      .impl_in_t  ( sram_cfg_t      )
-    ) i_data_mem (
-      .clk_i      ( clk_i           ),
-      .rst_ni     ( rst_ni          ),
-      .impl_i     ( sram_cfgs.tcdm  ),
-      .impl_o     (                 ), //Unused since it's SRAM dependent
-      .req_i      ( mem_cs          ),
-      .we_i       ( mem_wen         ),
-      .addr_i     ( mem_add         ),
-      .wdata_i    ( mem_wdata       ),
-      .be_i       ( mem_be          ),
-      .rdata_o    ( mem_rdata       )
+  for(genvar i = 0; i < NrSuperBanks; i++) begin: gen_tcdm_super_bank
+
+    mem_req_t [BanksPerSuperBank-1:0] amo_req;
+    mem_rsp_t [BanksPerSuperBank-1:0] amo_rsp;
+
+    mem_wide_narrow_mux #(
+      .NarrowDataWidth    ( NarrowDataWidth         ),
+      .WideDataWidth      ( WideDataWidth           ),
+      .mem_narrow_req_t   ( mem_req_t               ),
+      .mem_narrow_rsp_t   ( mem_rsp_t               ),
+      .mem_wide_req_t     ( mem_dma_req_t           ),
+      .mem_wide_rsp_t     ( mem_dma_rsp_t           )
+    ) i_tcdm_mux (
+      .clk_i              ( clk_i                   ),
+      .rst_ni             ( rst_ni                  ),
+      .in_narrow_req_i    ( narrow_req[i]           ),
+      .in_narrow_rsp_o    ( narrow_rsp[i]           ),
+      .in_wide_req_i      ( wide_dma_req[i]         ),
+      .in_wide_rsp_o      ( wide_dma_rsp[i]         ),
+      .out_req_o          ( amo_req                 ),
+      .out_rsp_i          ( amo_rsp                 ),
+      .sel_wide_i         ( wide_dma_req[i].q_valid )
     );
 
-    // Atomic memory operations
-    snitch_amo_shim #(
-      .AddrMemWidth   ( TCDMMemAddrWidth          ),
-      .DataWidth      ( NarrowDataWidth           ),
-      .CoreIDWidth    ( 5                         )
-    ) i_amo_shim (
-      .clk_i          ( clk_i                     ),
-      .rst_ni         ( rst_ni                    ),
-      .valid_i        ( mem_req[i].q_valid        ),
-      .ready_o        ( mem_rsp[i].q_ready        ),
-      .addr_i         ( mem_req[i].q.addr         ),
-      .write_i        ( mem_req[i].q.write        ),
-      .wdata_i        ( mem_req[i].q.data         ),
-      .wstrb_i        ( mem_req[i].q.strb         ),
-      .core_id_i      ( mem_req[i].q.user.core_id ),
-      .is_core_i      ( mem_req[i].q.user.is_core ),
-      .rdata_o        ( amo_rdata_local           ),
-      .amo_i          ( mem_req[i].q.amo          ),
-      .mem_req_o      ( mem_cs                    ),
-      .mem_add_o      ( mem_add                   ),
-      .mem_wen_o      ( mem_wen                   ),
-      .mem_wdata_o    ( mem_wdata                 ),
-      .mem_be_o       ( mem_be                    ),
-      .mem_rdata_i    ( mem_rdata                 ),
-      .dma_access_i   ( 1'b0                      ), // Unused since we don't simulate DMA here
-      .amo_conflict_o (                           )
-    );
+    // Generate multi-bank memories
+    // Number of banks matches number of memories
+    for (genvar j = 0; j < BanksPerSuperBank; j++) begin : gen_tcdm_bank
 
-    // Insert a pipeline register at the output of each SRAM.
-    shift_reg #(
-      .dtype  ( data_t            ),
-      .Depth  ( 0                 ) // Unused for now
-    ) i_sram_pipe (
-      .clk_i  ( clk_i             ),
-      .rst_ni ( rst_ni            ),
-      .d_i    ( amo_rdata_local   ),
-      .d_o    ( mem_rsp[i].p.data )
-    );
+      logic           mem_cs;
+      logic           mem_wen;
+      tcdm_mem_addr_t mem_add;
+      strb_t          mem_be;
+      data_t          mem_rdata;
+      data_t          mem_wdata;
+      data_t          amo_rdata_local;
+
+      tc_sram_impl #(
+        .NumWords   ( TCDMDepth       ),
+        .DataWidth  ( NarrowDataWidth ),
+        .ByteWidth  ( 8               ),
+        .NumPorts   ( 1               ),
+        .SimInit    ( "zeros"         ),
+        .Latency    ( 1               ),
+        .impl_in_t  ( sram_cfg_t      )
+      ) i_data_mem (
+        .clk_i      ( clk_i           ),
+        .rst_ni     ( rst_ni          ),
+        .impl_i     ( sram_cfgs.tcdm  ),
+        .impl_o     (                 ), //Unused since it's SRAM dependent
+        .req_i      ( mem_cs          ),
+        .we_i       ( mem_wen         ),
+        .addr_i     ( mem_add         ),
+        .wdata_i    ( mem_wdata       ),
+        .be_i       ( mem_be          ),
+        .rdata_o    ( mem_rdata       )
+      );
+
+      // Atomic memory operations
+      snitch_amo_shim #(
+        .AddrMemWidth   ( TCDMMemAddrWidth          ),
+        .DataWidth      ( NarrowDataWidth           ),
+        .CoreIDWidth    ( 5                         )
+      ) i_amo_shim (
+        .clk_i          ( clk_i                     ),
+        .rst_ni         ( rst_ni                    ),
+        .valid_i        ( amo_req[j].q_valid        ),
+        .ready_o        ( amo_rsp[j].q_ready        ),
+        .addr_i         ( amo_req[j].q.addr         ),
+        .write_i        ( amo_req[j].q.write        ),
+        .wdata_i        ( amo_req[j].q.data         ),
+        .wstrb_i        ( amo_req[j].q.strb         ),
+        .core_id_i      ( amo_req[j].q.user.core_id ),
+        .is_core_i      ( amo_req[j].q.user.is_core ),
+        .rdata_o        ( amo_rdata_local           ),
+        .amo_i          ( amo_req[j].q.amo          ),
+        .mem_req_o      ( mem_cs                    ),
+        .mem_add_o      ( mem_add                   ),
+        .mem_wen_o      ( mem_wen                   ),
+        .mem_wdata_o    ( mem_wdata                 ),
+        .mem_be_o       ( mem_be                    ),
+        .mem_rdata_i    ( mem_rdata                 ),
+        .dma_access_i   ( wide_dma_req[i].q_valid   ), // Unused since we don't simulate DMA here
+        .amo_conflict_o (                           )
+      );
+
+      // Insert a pipeline register at the output of each SRAM.
+      shift_reg #(
+        .dtype  ( data_t            ),
+        .Depth  ( 0                 ) // Unused for now
+      ) i_sram_pipe (
+        .clk_i  ( clk_i             ),
+        .rst_ni ( rst_ni            ),
+        .d_i    ( amo_rdata_local   ),
+        .d_o    ( amo_rsp[j].p.data )
+      );
+    end
   end
 
 endmodule

--- a/tests/cocotb/snax_util.py
+++ b/tests/cocotb/snax_util.py
@@ -248,8 +248,8 @@ async def tcdm_clr(dut, idx: int) -> None:
     return
 
 
-# Functions for TCDM control
-# Writing to TCDM
+# Functions for Wide TCDM control
+# Writing to Wide TCDM
 async def wide_tcdm_write(dut, addr: int, data: int) -> None:
     dut.tcdm_dma_req_addr_i.value = addr
     dut.tcdm_dma_req_data_i.value = data
@@ -261,7 +261,7 @@ async def wide_tcdm_write(dut, addr: int, data: int) -> None:
     return
 
 
-# Reading from TCDM
+# Reading from Wide TCDM
 async def wide_tcdm_read(dut, addr: int) -> int:
     dut.tcdm_dma_req_addr_i.value = addr
     dut.tcdm_dma_req_data_i.value = 0
@@ -275,7 +275,7 @@ async def wide_tcdm_read(dut, addr: int) -> int:
     return reg_read
 
 
-# Clear TCDM
+# Clear Wide TCDM
 async def wide_tcdm_clr(dut) -> None:
     dut.tcdm_dma_req_addr_i.value = 0
     dut.tcdm_dma_req_data_i.value = 0

--- a/tests/cocotb/test_tcdm_subsys.py
+++ b/tests/cocotb/test_tcdm_subsys.py
@@ -10,29 +10,49 @@
 # ---------------------------------
 
 import cocotb
-from cocotb.triggers import RisingEdge, Timer
 from cocotb.clock import Clock
 from cocotb_test.simulator import run
-from decimal import Decimal
 import pytest
 import snax_util
+import math
 
 # Configurable design time parameters
 NARROW_DATA_WIDTH = 64
+WIDE_DATA_WIDTH = 512
 TCDM_DEPTH = 64
-NR_BANKS = 8
+NR_BANKS = 32
 NUM_INPUT = 2
+
+# Configuration checker for the DMA wide
+# TCDM interconnection because
+# We need to make sure that the memory
+# and interconnect matches the addressing
+TCDM_SIZE = int(NR_BANKS * TCDM_DEPTH * NARROW_DATA_WIDTH / 8)
+TCDM_ADDR_WIDTH = math.ceil(math.log2(TCDM_SIZE))
+TCDM_MEM_ADDR_WIDTH = math.ceil(math.log2(TCDM_DEPTH))
+NR_BANKS_PER_SUPERBANK = WIDE_DATA_WIDTH / NARROW_DATA_WIDTH
+NR_SUPER_BANKS = int(NR_BANKS / NR_BANKS_PER_SUPERBANK)
+WIDE_TCDM_PORTS = math.ceil(math.log2(NR_SUPER_BANKS))
+WIDE_BYTE_OFFSET = math.ceil(math.log2(int(WIDE_DATA_WIDTH / 8)))
+
+assert TCDM_ADDR_WIDTH >= (
+    TCDM_MEM_ADDR_WIDTH + WIDE_TCDM_PORTS + WIDE_BYTE_OFFSET
+), "Error config! Make sure to satisfy the assertion equation"
 
 # Optinally configurable parameters
 NUM_OUTPUT = NR_BANKS
 MIN_VAL = 0
-MAX_VAL = 2**NARROW_DATA_WIDTH
-BANK_INCREMENT = NARROW_DATA_WIDTH / 8
+MAX_VAL = 2**NARROW_DATA_WIDTH - 1
+WIDE_MIN_VAL = 0
+WIDE_MAX_VAL = 2**WIDE_DATA_WIDTH - 1
+BANK_INCREMENT = int(NARROW_DATA_WIDTH / 8)
+WIDE_BANK_INCREMENT = int(BANK_INCREMENT * (WIDE_DATA_WIDTH / NARROW_DATA_WIDTH))
 
 # Configurable testing parameters
 # In the default value below, the number
 # of tests fills the entire memory
-NUM_TESTS = TCDM_DEPTH * NR_BANKS
+NUM_NARROW_TESTS = TCDM_DEPTH * NR_BANKS
+NUM_WIDE_TESTS = int(NUM_NARROW_TESTS / 8)
 
 
 @cocotb.test()
@@ -60,65 +80,73 @@ async def tcdm_subsys_dut(dut):
         dut.tcdm_req_strb_i[i].value = 0
         dut.tcdm_req_q_valid_i[i].value = 0
 
-    await RisingEdge(dut.clk_i)
-    await Timer(Decimal(1), units="ns")
+    dut.tcdm_dma_req_write_i.value = 0
+    dut.tcdm_dma_req_addr_i.value = 0
+    dut.tcdm_dma_req_data_i.value = 0
+    dut.tcdm_dma_req_strb_i.value = 0
+    dut.tcdm_dma_req_q_valid_i.value = 0
+
+    await snax_util.clock_and_wait(dut)
 
     # Release reset
     dut.rst_ni.value = 1
 
-    await RisingEdge(dut.clk_i)
-    await Timer(Decimal(1), units="ns")
+    await snax_util.clock_and_wait(dut)
 
     # Begin test
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info(" Testing for TCDM request and response ports")
+    cocotb.log.info(" ------------------------------------------ ")
     for i in range(NUM_INPUT):
-        golden_list = snax_util.gen_rand_int_list(NUM_TESTS, MIN_VAL, MAX_VAL)
+        golden_list = snax_util.gen_rand_int_list(NUM_NARROW_TESTS, MIN_VAL, MAX_VAL)
 
         # Cycle through values that change
         # Per item or element
         # Explicitly write the control signals
-        for j in range(len(golden_list)):
-            dut.tcdm_req_addr_i[i].value = int(j * BANK_INCREMENT)
-            dut.tcdm_req_data_i[i].value = golden_list[j]
-            dut.tcdm_req_strb_i[i].value = 0xFF
-            dut.tcdm_req_write_i[i].value = 1
-            dut.tcdm_req_q_valid_i[i].value = 1
-            await RisingEdge(dut.clk_i)
-            await Timer(Decimal(1), units="ns")
+        for j in range(NUM_NARROW_TESTS):
+            await snax_util.tcdm_write(dut, i, int(j * BANK_INCREMENT), golden_list[j])
 
         # Clear default inputs for reading
-        dut.tcdm_req_addr_i[i].value = 0
-        dut.tcdm_req_data_i[i].value = 0
-        dut.tcdm_req_strb_i[i].value = 0
-        dut.tcdm_req_write_i[i].value = 0
-        dut.tcdm_req_q_valid_i[i].value = 0
-        await RisingEdge(dut.clk_i)
-        await Timer(Decimal(1), units="ns")
+        await snax_util.tcdm_clr(dut, i)
 
         # Cycle through reads
         # And check immediately if result is correct
-        for j in range(len(golden_list)):
-            dut.tcdm_req_addr_i[i].value = int(j * BANK_INCREMENT)
-            dut.tcdm_req_data_i[i].value = 0
-            dut.tcdm_req_strb_i[i].value = 0
-            dut.tcdm_req_write_i[i].value = 0
-            dut.tcdm_req_q_valid_i[i].value = 1
-            await RisingEdge(dut.clk_i)
-            await Timer(Decimal(1), units="ns")
-
+        for j in range(NUM_NARROW_TESTS):
+            check_val = await snax_util.tcdm_read(dut, i, int(j * BANK_INCREMENT))
             # Check for results
-            check_val = int(dut.tcdm_rsp_data_o[i].value)
             cocotb.log.info(f"Port {i} Actual output: {check_val}")
             cocotb.log.info(f"Golden output: {golden_list[j]}")
             assert check_val == golden_list[j]
 
         # Clear default inputs for reading
-        dut.tcdm_req_addr_i[i].value = 0
-        dut.tcdm_req_data_i[i].value = 0
-        dut.tcdm_req_strb_i[i].value = 0
-        dut.tcdm_req_write_i[i].value = 0
-        dut.tcdm_req_q_valid_i[i].value = 0
-        await RisingEdge(dut.clk_i)
-        await Timer(Decimal(1), units="ns")
+        await snax_util.tcdm_clr(dut, i)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info(" Wide TCDM tests for the DMA transfers")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Get golden data
+    wide_golden_list = snax_util.gen_rand_int_list(
+        NUM_WIDE_TESTS, WIDE_MIN_VAL, WIDE_MAX_VAL
+    )
+
+    # Write data to TCDM
+    for i in range(NUM_WIDE_TESTS):
+        await snax_util.wide_tcdm_write(
+            dut, i * WIDE_BANK_INCREMENT, wide_golden_list[i]
+        )
+        print(i * WIDE_BANK_INCREMENT)
+
+    # Write to clear
+    await snax_util.wide_tcdm_clr(dut)
+
+    # Read data from TCDM
+    for i in range(NUM_WIDE_TESTS):
+        check_val = await snax_util.wide_tcdm_read(dut, int(i * WIDE_BANK_INCREMENT))
+        # Check for results
+        cocotb.log.info(f"Actual output: {check_val}")
+        cocotb.log.info(f"Golden output: {wide_golden_list[i]}")
+        assert check_val == wide_golden_list[i]
 
 
 # Main test run
@@ -127,10 +155,10 @@ async def tcdm_subsys_dut(dut):
     [
         {
             "NarrowDataWidth": str(NARROW_DATA_WIDTH),
+            "WideDataWidth": str(WIDE_DATA_WIDTH),
             "TCDMDepth": str(TCDM_DEPTH),
             "NrBanks": str(NR_BANKS),
             "NumInp": str(NUM_INPUT),
-            "NumOut": str(NUM_OUTPUT),
         }
     ],
 )
@@ -178,4 +206,5 @@ def test_tcdm_subsys(parameters, simulator):
         sim_build=sim_build,
         compile_args=compile_args,
         timescale=timescale,
+        parameters=parameters,
     )

--- a/tests/cocotb/test_tcdm_subsys.py
+++ b/tests/cocotb/test_tcdm_subsys.py
@@ -27,6 +27,7 @@ NUM_INPUT = 2
 # TCDM interconnection because
 # We need to make sure that the memory
 # and interconnect matches the addressing
+# note that this is an internal checker
 TCDM_SIZE = int(NR_BANKS * TCDM_DEPTH * NARROW_DATA_WIDTH / 8)
 TCDM_ADDR_WIDTH = math.ceil(math.log2(TCDM_SIZE))
 TCDM_MEM_ADDR_WIDTH = math.ceil(math.log2(TCDM_DEPTH))

--- a/tests/tb/tb_tcdm_subsys.sv
+++ b/tests/tb/tb_tcdm_subsys.sv
@@ -1,14 +1,14 @@
 //-----------------------------------
-// Tightly Coupled Data Memory Sub-System 
+// Tightly Coupled Data Memory Sub-System
 // Local testbench
 //-----------------------------------
 
 module tb_tcdm_subsys #(
   parameter int unsigned NarrowDataWidth   = 64,
+  parameter int unsigned WideDataWidth     = 512,
   parameter int unsigned TCDMDepth         = 64,
   parameter int unsigned NrBanks           = 8,
-  parameter int unsigned NumInp            = 2,
-  parameter int unsigned NumOut            = NrBanks
+  parameter int unsigned NumInp            = 2
 );
 
   // Local parameters that need to be managed automatically
@@ -48,6 +48,15 @@ module tb_tcdm_subsys #(
   logic [0:0]                   tcdm_rsp_p_valid_o      [NumInp];
   logic [NarrowDataWidth-1:0]   tcdm_rsp_data_o         [NumInp];
 
+  logic                       tcdm_dma_req_write_i;
+  logic [  TCDMAddrWidth-1:0] tcdm_dma_req_addr_i;
+  logic [  WideDataWidth-1:0] tcdm_dma_req_data_i;
+  logic [WideDataWidth/8-1:0] tcdm_dma_req_strb_i;
+  logic                       tcdm_dma_req_q_valid_i;
+  logic                       tcdm_dma_rsp_q_ready_o;
+  logic                       tcdm_dma_rsp_p_valid_o;
+  logic [  WideDataWidth-1:0] tcdm_dma_rsp_data_o;
+
   // Hard re-mapping just to handle the cocotb verilator translation
   always_comb begin
     for(int i = 0; i < NumInp; i++) begin
@@ -70,10 +79,15 @@ module tb_tcdm_subsys #(
     .TCDMDepth                ( TCDMDepth             ),
     .NrBanks                  ( NrBanks               ),
     .NumInp                   ( NumInp                ),
-    .NumOut                   ( NumOut                )
   ) i_tcdm_subsys (
+    //-----------------------------
+    // Clock and reset
+    //-----------------------------
     .clk_i                    ( clk_i                 ),
     .rst_ni                   ( rst_ni                ),
+    //-----------------------------
+    // TCDM ports
+    //-----------------------------
     .tcdm_req_write_i         ( tcdm_req_write        ),
     .tcdm_req_addr_i          ( tcdm_req_addr         ),
     .tcdm_req_amo_i           ( tcdm_req_amo          ),
@@ -84,7 +98,18 @@ module tb_tcdm_subsys #(
     .tcdm_req_q_valid_i       ( tcdm_req_q_valid      ),
     .tcdm_rsp_q_ready_o       ( tcdm_rsp_q_ready      ),
     .tcdm_rsp_p_valid_o       ( tcdm_rsp_p_valid      ),
-    .tcdm_rsp_data_o          ( tcdm_rsp_data         )
+    .tcdm_rsp_data_o          ( tcdm_rsp_data         ),
+    //-----------------------------
+    // Wide TCDM ports
+    //-----------------------------
+    .tcdm_dma_req_write_i     ( tcdm_dma_req_write_i   ),
+    .tcdm_dma_req_addr_i      ( tcdm_dma_req_addr_i    ),
+    .tcdm_dma_req_data_i      ( tcdm_dma_req_data_i    ),
+    .tcdm_dma_req_strb_i      ( tcdm_dma_req_strb_i    ),
+    .tcdm_dma_req_q_valid_i   ( tcdm_dma_req_q_valid_i ),
+    .tcdm_dma_rsp_q_ready_o   ( tcdm_dma_rsp_q_ready_o ),
+    .tcdm_dma_rsp_p_valid_o   ( tcdm_dma_rsp_p_valid_o ),
+    .tcdm_dma_rsp_data_o      ( tcdm_dma_rsp_data_o    )
   );
 
 endmodule


### PR DESCRIPTION
This PR adds the full TCDM subsystem of the SNAX cluster. It's now a more accurate replication where a DMA port is also added. After carefully studying the TCDM of the SNAX cluster, we have the following figure:

![image](https://github.com/KULeuven-MICAS/snax-dev/assets/26665295/b805751e-3ec6-48ad-961d-829efe360316)

A few notable parts are:
- There are 2 TCDM structures: the first one uses a narrow data width (64b) per port which is for the cores and accelerators, while the other is a wide data width (512b) per port used for the DMA.
- The DMA TCDM only has 1 port for the DMA but then splits into 4 ports. This depends on the configuration of the TCDM size, number of banks, and wide data width of course. Computed internally but by default this is in the SNAX cluster.
- There exists `WIDE_MEM_MUX` found closer to the actual memory system. This was to cater to the need for DMA ports. Note that DMA transactions take priority based on how the `WIDE_MEM_MUX` modules were built.

This PR contains:
- Added the DMA ports connecting to the TCDM subsystem. It includes the `MEM_WIDE_MUX` and the `DMA TCDM` interconnect.
- Upgraded the TCDM test to include this
- Added functions to `snax_util.py` for TCDM narrow and wide transactions.
- Refactored some code to be re-usable as functions instead.