### PR TITLE
Add TCDM-Streamer combination test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,6 @@ on:
     branches: [main]
 
 jobs:
-  streamer-test-gen:
-    name: Template generation test
-    runs-on: ubuntu-22.04
-    container:
-      image: ghcr.io/kuleuven-micas/snax-cocotb
-    steps:
-      - uses: actions/checkout@v3
-      - name: Generate SNAX streamer
-        run: |
-          make gen_stream_tb
-
   rtl-test-vlt:
     name: RTL test using verilator
     runs-on: ubuntu-22.04

--- a/Bender.yml
+++ b/Bender.yml
@@ -13,4 +13,4 @@ package:
 dependencies:
   # No existing tags for snitch_cluster, so this rev hash is the latest update as of Aug 20, 2023
   snitch_cluster: { git: "https://github.com/KULeuven-MICAS/snitch_cluster", rev: 1da938ddfdc60d3409cbac69db0cc7d05700e013 }
-  snax-streamer: { git: "https://github.com/KULeuven-MICAS/snax-streamer", rev: 059458498a0386f9ca87fc6ee7d7a9d4ad7b0106 }
+  snax-streamer: { git: "https://github.com/KULeuven-MICAS/snax-streamer", rev: 530c582f99f588644609bd7718e66add848f5c63 }

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ $(STREAM_GEN_OUT_RTL_FILE):
 #-----------------------------
 # Generate Streamer Wrapper Testbench
 #-----------------------------
-gen_stream_tb:	$(STREAM_GEN_OUT_SCALA_FILE) $(STREAM_GEN_OUT_TOP_FILE) $(STREAM_GEN_OUT_RTL_FILE)
+${STREAM_GEN_OUT_TB_FILE}:	$(STREAM_GEN_OUT_SCALA_FILE) $(STREAM_GEN_OUT_TOP_FILE) $(STREAM_GEN_OUT_RTL_FILE)
 	${PYTHON} util/scripts/template_gen.py --cfg_path="${STREAM_GEN_CFG_FILE}" \
 	--tpl_path="${STREAM_GEN_TPL_TB_FILE}" \
 	--out_path="${STREAM_GEN_OUT_TB_FILE}"
@@ -88,7 +88,7 @@ gen_stream_tb:	$(STREAM_GEN_OUT_SCALA_FILE) $(STREAM_GEN_OUT_TOP_FILE) $(STREAM_
 #-----------------------------
 # Generate Streamer-TCDM Wrapper Testbench
 #-----------------------------
-gen_stream_tcdm_tb:	$(STREAM_GEN_OUT_SCALA_FILE) $(STREAM_GEN_OUT_TOP_FILE) $(STREAM_GEN_OUT_RTL_FILE)
+${STREAM_TCDM_GEN_OUT_TB_FILE}:	$(STREAM_GEN_OUT_SCALA_FILE) $(STREAM_GEN_OUT_TOP_FILE) $(STREAM_GEN_OUT_RTL_FILE)
 	${PYTHON} util/scripts/template_gen.py --cfg_path="${STREAM_GEN_CFG_FILE}" \
 	--tpl_path="${STREAM_TCDM_GEN_TPL_TB_FILE}" \
 	--out_path="${STREAM_TCDM_GEN_OUT_TB_FILE}"

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,20 @@ PYTHON = python3
 # Default Filename Declarations
 #-----------------------------
 STREAM_CFG_FILENAME ?= streamer_cfg.hjson
+
 STREAM_TPL_RTL_FILENAME ?= streamer_wrapper.sv.tpl
-STREAM_TPL_TB_FILENAME ?= tb_streamer_top.sv.tpl
 STREAM_TPL_SCALA_FILENAME ?= StreamParamGen.scala.tpl
+STREAM_TPL_TB_FILENAME ?= tb_streamer_top.sv.tpl
+STREAM_TCDM_TPL_TB_FILENAME ?= tb_stream_tcdm_top.sv.tpl
+
 STREAM_WRAPPER_FILENAME ?= streamer_wrapper.sv
+
 STREAM_SCALA_PARAM_FILENAME ?= StreamParamGen.scala
-STREAM_TB_FILENAME ?= tb_streamer_top.sv
+
 STREAM_TOP_FILENAME ?= StreamerTop.sv
+
+STREAM_TB_FILENAME ?= tb_streamer_top.sv
+STREAM_TCDM_TB_FILENAME ?= tb_stream_tcdm_top.sv
 
 #-----------------------------
 # Default Path Declarations 
@@ -31,13 +38,20 @@ STREAM_OUT_TOP_PATH ?= ${STREAM_OUT_RTL_PATH}
 # Default Path and File Declarations
 #-----------------------------
 STREAM_GEN_CFG_FILE = ${STREAM_CFG_PATH}/${STREAM_CFG_FILENAME}
+
 STREAM_GEN_TPL_RTL_FILE = ${STREAM_TPL_PATH}/${STREAM_TPL_RTL_FILENAME}
 STREAM_GEN_TPL_TB_FILE = ${STREAM_TPL_PATH}/${STREAM_TPL_TB_FILENAME}
+STREAM_TCDM_GEN_TPL_TB_FILE = ${STREAM_TPL_PATH}/${STREAM_TCDM_TPL_TB_FILENAME}
 STREAM_GEN_TPL_SCALA_FILE = ${STREAM_TPL_PATH}/${STREAM_TPL_SCALA_FILENAME}
-STREAM_GEN_OUT_RTL_FILE = $(STREAM_OUT_RTL_PATH)/${STREAM_WRAPPER_FILENAME}
-STREAM_GEN_OUT_TB_FILE = $(STREAM_OUT_TB_PATH)/${STREAM_TB_FILENAME}
+
 STREAM_GEN_OUT_SCALA_FILE = ${STREAM_OUT_SCALA_PATH}/${STREAM_SCALA_PARAM_FILENAME}
+
+STREAM_GEN_OUT_RTL_FILE = $(STREAM_OUT_RTL_PATH)/${STREAM_WRAPPER_FILENAME}
+
 STREAM_GEN_OUT_TOP_FILE = $(STREAM_OUT_TOP_PATH)/${STREAM_TOP_FILENAME}
+
+STREAM_GEN_OUT_TB_FILE = $(STREAM_OUT_TB_PATH)/${STREAM_TB_FILENAME}
+STREAM_TCDM_GEN_OUT_TB_FILE = $(STREAM_OUT_TB_PATH)/${STREAM_TCDM_TB_FILENAME}
 
 #-----------------------------
 # Generate Streamer Scala Parameter
@@ -72,7 +86,16 @@ gen_stream_tb:	$(STREAM_GEN_OUT_SCALA_FILE) $(STREAM_GEN_OUT_TOP_FILE) $(STREAM_
 	--out_path="${STREAM_GEN_OUT_TB_FILE}"
 
 #-----------------------------
+# Generate Streamer-TCDM Wrapper Testbench
+#-----------------------------
+gen_stream_tcdm_tb:	$(STREAM_GEN_OUT_SCALA_FILE) $(STREAM_GEN_OUT_TOP_FILE) $(STREAM_GEN_OUT_RTL_FILE)
+	${PYTHON} util/scripts/template_gen.py --cfg_path="${STREAM_GEN_CFG_FILE}" \
+	--tpl_path="${STREAM_TCDM_GEN_TPL_TB_FILE}" \
+	--out_path="${STREAM_TCDM_GEN_OUT_TB_FILE}"
+
+#-----------------------------
 # Clean
 #-----------------------------
 clean:
-	rm -f ${STREAM_GEN_OUT_RTL_FILE} ${STREAM_GEN_OUT_SCALA_FILE} ${STREAM_GEN_OUT_TOP_FILE} ${STREAM_GEN_OUT_TB_FILE}
+	rm -f ${STREAM_GEN_OUT_RTL_FILE} ${STREAM_GEN_OUT_SCALA_FILE} \
+	${STREAM_GEN_OUT_TOP_FILE} ${STREAM_GEN_OUT_TB_FILE} ${STREAM_TCDM_GEN_OUT_TB_FILE}

--- a/tests/cocotb/snax_util.py
+++ b/tests/cocotb/snax_util.py
@@ -155,9 +155,33 @@ def gen_rand_int_list(list_len: int, min_val: int, max_val: int) -> List[int]:
     return uint_list
 
 
+# This is for repacking data from a contigious list
+# into a list of packed data for DMA read and write chunks
+def gen_wide_list(
+    narrow_list: List[int], narrow_width: int, wide_width: int
+) -> List[int]:
+    # This one checks if the number of narrow elements
+    # Is divisible by the ratio of wide and narrow widths
+    # Otherwise you will not utilize the entire DMA
+    wide_list = []
+    wide_narrow_ratio = int(wide_width / narrow_width)
+    if len(narrow_list) % wide_narrow_ratio:
+        print("WARNING! Number of elements and wide-narrow ratio are not divisible")
+
+    wide_len = int(len(narrow_list) / wide_narrow_ratio)
+
+    for i in range(wide_len):
+        wide_num = 0
+        for j in range(wide_narrow_ratio - 1, -1, -1):
+            wide_num += narrow_list[i * wide_narrow_ratio + j] << (narrow_width * j)
+        wide_list.append(wide_num)
+
+    return wide_list
+
+
 # Compare and assert
 def comp_and_assert(golden_data: int, actual_data: int) -> None:
-    cocotb.log.info(f"Golden data: {golden_data}; Actual data: {actual_data}")
+    cocotb.log.info(f"Golden data: {hex(golden_data)}; Actual data: {hex(actual_data)}")
     assert golden_data == actual_data
     return
 

--- a/tests/cocotb/test_basic_streamer.py
+++ b/tests/cocotb/test_basic_streamer.py
@@ -201,9 +201,9 @@ def test_basic_streamer(simulator, waves):
 
     # Make sure to generate the StreamerTop.sv
     # If it does not exist
-    streamer_top_file = repo_path + "/rtl/StreamerTop.sv"
+    streamer_top_file = repo_path + "/tests/tb/tb_streamer_top.sv"
     if not os.path.exists(streamer_top_file):
-        subprocess.run(["make", "gen_stream_tb"])
+        subprocess.run(["make", streamer_top_file])
 
     verilog_sources = [
         repo_path + "/rtl/StreamerTop.sv",

--- a/tests/cocotb/test_stream_tcdm.py
+++ b/tests/cocotb/test_stream_tcdm.py
@@ -277,8 +277,8 @@ def test_stream_tcdm(simulator, waves):
 
     # Make sure to generate the StreamerTop.sv
     # If it does not exist
-    streamer_top_file = repo_path + "/rtl/StreamerTop.sv"
-    if not os.path.exists(streamer_top_file):
+    stream_tcdm_tb_file = repo_path + "/tests/tb/tb_stream_tcdm_top.sv"
+    if not os.path.exists(stream_tcdm_tb_file):
         subprocess.run(["make", "gen_stream_tcdm_tb"])
 
     streamer_verilog_sources = [
@@ -290,7 +290,7 @@ def test_stream_tcdm(simulator, waves):
     tcdm_includes, tcdm_verilog_sources = snax_util.extract_tcdm_list()
 
     tb_verilog_source = [
-        repo_path + "/tests/tb/tb_stream_tcdm_top.sv",
+        stream_tcdm_tb_file,
     ]
 
     verilog_sources = (

--- a/tests/cocotb/test_stream_tcdm.py
+++ b/tests/cocotb/test_stream_tcdm.py
@@ -1,0 +1,341 @@
+# ---------------------------------
+# Copyright 2024 KULeuven
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+# Author: Ryan Antonio (ryan.antonio@esat.kuleuven.be)
+#
+# Description:
+# This tests the basic configuration of the streamer
+# found in ./util/cfg/streamer_cfg.hjson
+#
+# Sequence of tests:
+# 1. First test read and write to CSR registers
+# 2. Check if the output addresses of TCDM
+#    are correct and valid
+# ---------------------------------
+
+import cocotb
+from cocotb.triggers import RisingEdge, Timer
+from cocotb.clock import Clock
+from cocotb_test.simulator import run
+import snax_util
+import os
+import subprocess
+from decimal import Decimal
+
+# Configurable design time parameters
+TCDM_REQ_PORTS = 12
+NARROW_DATA_WIDTH = 64
+WIDE_DATA_WIDTH = 512
+TCDM_DEPTH = 64
+NR_BANKS = 32
+NUM_INPUT = 2
+
+# Configurable testing parameters
+# In the default value below, the number
+# of tests fills the entire memory
+BANK_INCREMENT = int(NARROW_DATA_WIDTH / 8)
+WIDE_BANK_INCREMENT = int(WIDE_DATA_WIDTH / 8)
+WIDE_NARROW_RATIO = int(WIDE_DATA_WIDTH / NARROW_DATA_WIDTH)
+NUM_NARROW_TESTS = TCDM_DEPTH * NR_BANKS
+NUM_WIDE_TESTS = int(NUM_NARROW_TESTS / 8)
+MIN_VAL = 0
+MAX_NARROW_VAL = 2**NARROW_DATA_WIDTH
+MAX_WIDE_VAL = 2**WIDE_DATA_WIDTH
+
+# DON'T TOUCH ME PLEASE
+# CSR parameters from the default
+# Configuration found under util/cfg/streamer_cfg.hjson
+# Also some pre-computed that are fixed
+CSR_LOOP_COUNT_0 = 0
+CSR_TEMPORAL_STRIDE_0 = 1
+CSR_TEMPORAL_STRIDE_1 = 2
+CSR_TEMPORAL_STRIDE_2 = 3
+CSR_SPATIAL_STRIDE_0 = 4
+CSR_SPATIAL_STRIDE_1 = 5
+CSR_SPATIAL_STRIDE_2 = 6
+CSR_BASE_PTR_0 = 7
+CSR_BASE_PTR_1 = 8
+CSR_BASE_PTR_2 = 9
+CSR_START_STREAMER = 10
+
+
+@cocotb.test()
+async def stream_tcdm_dut(dut):
+    # Value configurations you can set
+    # For exploration and testing
+    # These values go into the respective
+    # CSR register addresses above
+    LOOP_COUNT_0 = 20
+    TEMPORAL_STRIDE_0 = 64
+    TEMPORAL_STRIDE_1 = 64
+    TEMPORAL_STRIDE_2 = 64
+    SPATIAL_STRIDE_0 = 8
+    SPATIAL_STRIDE_1 = 8
+    SPATIAL_STRIDE_2 = 8
+    BASE_PTR_0 = 0
+    BASE_PTR_1 = 32
+    BASE_PTR_2 = 0
+
+    # Start clock
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start())
+
+    # Initial reset values
+    # Need to clear for modelsim (or other simulator)
+    # Verilator assumes 0, no don't care states
+    dut.rst_ni.value = 0
+
+    # Always active assuming core can
+    # contiuously read data from streamer CSR
+    dut.io_csr_rsp_ready_i.value = 1
+
+    # From the accelerator ports to streamer ports
+    # Tie the valid and ready to 1
+    # So that we can see address changes
+    dut.acc2stream_data_0_bits_i.value = 0
+    dut.acc2stream_data_0_valid_i.value = 0
+    dut.stream2acc_data_0_ready_i.value = 1
+    dut.stream2acc_data_1_ready_i.value = 1
+
+    # Set DMA ports to 0 first before driving
+    dut.tcdm_dma_req_write_i.value = 0
+    dut.tcdm_dma_req_addr_i.value = 0
+    dut.tcdm_dma_req_data_i.value = 0
+    dut.tcdm_dma_req_strb_i.value = 0
+    dut.tcdm_dma_req_q_valid_i.value = 0
+
+    await snax_util.clock_and_wait(dut)
+
+    # Release reset
+    dut.rst_ni.value = 1
+
+    await snax_util.clock_and_wait(dut)
+
+    # Preload data into the TCDM subsys
+    # using the DMA ports
+    cocotb.log.info("Preload data with DMA control")
+
+    # Generate data to be processed
+    # Number of elements is dependent on:
+    # LOOP_COUNT_0 x (WIDE_DATA_WIDTH / NARROW_DATA_WIDTH)
+    narrow_golden_list = snax_util.gen_rand_int_list(
+        int(LOOP_COUNT_0 * (WIDE_DATA_WIDTH / NARROW_DATA_WIDTH)), MIN_VAL, 255
+    )
+    wide_golden_list = snax_util.gen_wide_list(
+        narrow_golden_list, NARROW_DATA_WIDTH, WIDE_DATA_WIDTH
+    )
+
+    narrow_writer_golden_list = snax_util.gen_rand_int_list(
+        int(LOOP_COUNT_0 * (WIDE_DATA_WIDTH / NARROW_DATA_WIDTH / 2)), MIN_VAL, 255
+    )
+    wide_writer_golden_list = snax_util.gen_wide_list(
+        narrow_writer_golden_list, NARROW_DATA_WIDTH, 256
+    )
+
+    # Preload TCDM DMA subsys using DMA ports
+    wide_len = len(wide_golden_list)
+    for i in range(wide_len):
+        await snax_util.wide_tcdm_write(
+            dut, i * WIDE_BANK_INCREMENT, wide_golden_list[i]
+        )
+
+    await snax_util.wide_tcdm_clr(dut)
+
+    # Sanity check contents loaded into DMA
+    for i in range(wide_len):
+        tcdm_wide_val = await snax_util.wide_tcdm_read(dut, i * WIDE_BANK_INCREMENT)
+        snax_util.comp_and_assert(wide_golden_list[i], tcdm_wide_val)
+
+    await snax_util.wide_tcdm_clr(dut)
+
+    cocotb.log.info("Setting up of CSR registers and verifying if setup is correct")
+
+    # At this point we'll do explicit declartion
+    # of the tests so that it's understandable
+    # for other users
+
+    # Set number of iterations
+    await snax_util.reg_write(dut, CSR_LOOP_COUNT_0, LOOP_COUNT_0)
+
+    # Set temporal strides
+    await snax_util.reg_write(dut, CSR_TEMPORAL_STRIDE_0, TEMPORAL_STRIDE_0)
+    await snax_util.reg_write(dut, CSR_TEMPORAL_STRIDE_1, TEMPORAL_STRIDE_1)
+    await snax_util.reg_write(dut, CSR_TEMPORAL_STRIDE_2, TEMPORAL_STRIDE_2)
+
+    # Set spatial strides
+    await snax_util.reg_write(dut, CSR_SPATIAL_STRIDE_0, SPATIAL_STRIDE_0)
+    await snax_util.reg_write(dut, CSR_SPATIAL_STRIDE_1, SPATIAL_STRIDE_1)
+    await snax_util.reg_write(dut, CSR_SPATIAL_STRIDE_2, SPATIAL_STRIDE_2)
+
+    # Set base pointers
+    await snax_util.reg_write(dut, CSR_BASE_PTR_0, BASE_PTR_0)
+    await snax_util.reg_write(dut, CSR_BASE_PTR_1, BASE_PTR_1)
+    await snax_util.reg_write(dut, CSR_BASE_PTR_2, BASE_PTR_2)
+
+    # Clear driver signals
+    # So that we don't have stuck valid
+    await snax_util.reg_clr(dut)
+
+    # Read and verify the contents
+    # of the previously set registers
+    reg_val = await snax_util.reg_read(dut, CSR_LOOP_COUNT_0)
+    snax_util.comp_and_assert(LOOP_COUNT_0, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_TEMPORAL_STRIDE_0)
+    snax_util.comp_and_assert(TEMPORAL_STRIDE_0, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_TEMPORAL_STRIDE_1)
+    snax_util.comp_and_assert(TEMPORAL_STRIDE_1, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_TEMPORAL_STRIDE_2)
+    snax_util.comp_and_assert(TEMPORAL_STRIDE_2, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_SPATIAL_STRIDE_0)
+    snax_util.comp_and_assert(SPATIAL_STRIDE_0, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_SPATIAL_STRIDE_1)
+    snax_util.comp_and_assert(SPATIAL_STRIDE_1, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_SPATIAL_STRIDE_2)
+    snax_util.comp_and_assert(SPATIAL_STRIDE_2, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_BASE_PTR_0)
+    snax_util.comp_and_assert(BASE_PTR_0, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_BASE_PTR_1)
+    snax_util.comp_and_assert(BASE_PTR_1, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_BASE_PTR_2)
+    snax_util.comp_and_assert(BASE_PTR_2, reg_val)
+    await snax_util.reg_clr(dut)
+
+    # In this test we simply continuously
+    # stream the data in the stream to accelerator ports
+    # and check if the data is consistent with the preloaded data
+    cocotb.log.info("Run the streamer and check if data are correct")
+
+    # Write anything to CSR_STAR_STREAMER CSR
+    # adderss to activate the streamer
+    await snax_util.reg_write(dut, CSR_START_STREAMER, 0)
+    await snax_util.reg_clr(dut)
+
+    # Wait for the rising edge of the valid
+    # From there we can continuously stream for ever clock cycle
+    await RisingEdge(dut.stream2acc_data_0_valid_o)
+
+    # Necessary for cocotb evaluation step
+    await Timer(Decimal(1), units="ps")
+
+    for i in range(LOOP_COUNT_0):
+        # Extract the data
+        read_stream_0 = int(dut.stream2acc_data_0_bits_o.value)
+        read_stream_1 = int(dut.stream2acc_data_1_bits_o.value)
+
+        # Combine data into 512 bits wide
+        # Note that each reader port is 256 bits only
+        # Compare combined data to the wide golden list
+        combined_val = read_stream_0 + (read_stream_1 << 256)
+        snax_util.comp_and_assert(wide_golden_list[i], combined_val)
+        await snax_util.clock_and_wait(dut)
+
+    # In this test the writer is streamed continuosly
+    # then we read through one of the reader ports
+    cocotb.log.info("Writer-reader test")
+
+    # Allow the writer to write data unto the streamer
+    writer_len = len(wide_writer_golden_list)
+    for i in range(writer_len):
+        dut.acc2stream_data_0_bits_i.value = wide_writer_golden_list[i]
+        dut.acc2stream_data_0_valid_i.value = 1
+        await snax_util.clock_and_wait(dut)
+
+    # Clear step to avoid overwriting
+    dut.acc2stream_data_0_bits_i.value = 0
+    dut.acc2stream_data_0_valid_i.value = 0
+    await snax_util.clock_and_wait(dut)
+
+    # Switch off 2nd reader since the
+    # 1st reader will be the only one used
+    dut.stream2acc_data_1_ready_i.value = 0
+    await snax_util.clock_and_wait(dut)
+
+    # Start streamer again
+    await snax_util.reg_write(dut, CSR_START_STREAMER, 0)
+    await snax_util.reg_clr(dut)
+
+    # Wait for the rising edge of the valid
+    # From here we can continuously stream for ever clock cycle
+    await RisingEdge(dut.stream2acc_data_0_valid_o)
+    # Necessary for cocotb evaluation step
+    await Timer(Decimal(1), units="ps")
+
+    for i in range(LOOP_COUNT_0):
+        # Extract the data
+        read_stream_0 = int(dut.stream2acc_data_0_bits_o.value)
+
+        # Streamed data should be consistent
+        snax_util.comp_and_assert(wide_writer_golden_list[i], read_stream_0)
+        await snax_util.clock_and_wait(dut)
+
+
+# Main test run
+def test_stream_tcdm(simulator, waves):
+    repo_path = os.getcwd()
+    tests_path = repo_path + "/tests/cocotb/"
+
+    # Make sure to generate the StreamerTop.sv
+    # If it does not exist
+    streamer_top_file = repo_path + "/rtl/StreamerTop.sv"
+    if not os.path.exists(streamer_top_file):
+        subprocess.run(["make", "gen_stream_tcdm_tb"])
+
+    streamer_verilog_sources = [
+        repo_path + "/rtl/StreamerTop.sv",
+        repo_path + "/rtl/streamer_wrapper.sv",
+    ]
+
+    # Extract TCDM components
+    tcdm_includes, tcdm_verilog_sources = snax_util.extract_tcdm_list()
+
+    tb_verilog_source = [
+        repo_path + "/tests/tb/tb_stream_tcdm_top.sv",
+    ]
+
+    verilog_sources = (
+        tcdm_verilog_sources + streamer_verilog_sources + tb_verilog_source
+    )
+
+    defines = []
+    includes = [] + tcdm_includes
+
+    toplevel = "tb_stream_tcdm_top"
+
+    module = "test_stream_tcdm"
+
+    sim_build = tests_path + "/sim_build/{}/".format(toplevel)
+
+    if simulator == "verilator":
+        compile_args = [
+            "-Wno-LITENDIAN",
+            "-Wno-WIDTH",
+            "-Wno-CASEINCOMPLETE",
+            "-Wno-BLKANDNBLK",
+            "-Wno-CMPCONST",
+            "-Wno-WIDTHCONCAT",
+            "-Wno-UNSIGNED",
+            "-Wno-UNOPTFLAT",
+            "-Wno-TIMESCALEMOD",
+            "-Wno-fatal",
+            "--no-timing",
+            "--trace",
+            "--trace-structs",
+        ]
+        timescale = None
+    else:
+        compile_args = None
+        timescale = "1ns/1ps"
+
+    run(
+        verilog_sources=verilog_sources,
+        includes=includes,
+        toplevel=toplevel,
+        defines=defines,
+        module=module,
+        simulator=simulator,
+        sim_build=sim_build,
+        compile_args=compile_args,
+        waves=waves,
+        timescale=timescale,
+    )

--- a/tests/cocotb/test_stream_tcdm.py
+++ b/tests/cocotb/test_stream_tcdm.py
@@ -279,7 +279,7 @@ def test_stream_tcdm(simulator, waves):
     # If it does not exist
     stream_tcdm_tb_file = repo_path + "/tests/tb/tb_stream_tcdm_top.sv"
     if not os.path.exists(stream_tcdm_tb_file):
-        subprocess.run(["make", "gen_stream_tcdm_tb"])
+        subprocess.run(["make", stream_tcdm_tb_file])
 
     streamer_verilog_sources = [
         repo_path + "/rtl/StreamerTop.sv",

--- a/util/cfg/streamer_cfg.hjson
+++ b/util/cfg/streamer_cfg.hjson
@@ -65,6 +65,7 @@
     // numBanks - Total number of banks
     //--------------------------------
     tcdmDataWidth: 64,
+    tcdmDmaDataWidth: 512,
     tcdmDepth: 256,
     numBanks: 32,
 }

--- a/util/templates/tb_stream_tcdm_top.sv.tpl
+++ b/util/templates/tb_stream_tcdm_top.sv.tpl
@@ -1,0 +1,218 @@
+<%
+  import math
+
+  num_loop_dim = cfg["temporalAddrGenUnitParams"]["loopDim"]
+  num_data_mover = (len(cfg["dataReaderParams"]["tcdmPortsNum"]) + len(cfg["dataWriterParams"]["tcdmPortsNum"])) 
+  num_dmove_x_loop_dim = num_data_mover * num_loop_dim
+  num_spatial_dim = sum(cfg["dataReaderParams"]["spatialDim"]) + sum(cfg["dataWriterParams"]["spatialDim"])
+  
+  csr_num = num_loop_dim + num_dmove_x_loop_dim + num_data_mover + num_spatial_dim + 1
+  csr_width = math.ceil(math.log2(csr_num))
+%>
+//-----------------------------------
+// Basic SNAX streamer testbench
+//-----------------------------------
+module tb_stream_tcdm_top;
+
+  localparam int unsigned NarrowDataWidth = ${cfg["tcdmDataWidth"]};
+  localparam int unsigned WideDataWidth = ${cfg["tcdmDmaDataWidth"]};
+  localparam int unsigned TCDMDepth = ${cfg["tcdmDepth"]};
+  localparam int unsigned TCDMReqPorts = ${sum(cfg["dataReaderParams"]["tcdmPortsNum"]) + sum(cfg["dataWriterParams"]["tcdmPortsNum"])};
+  localparam int unsigned NrBanks = ${cfg["numBanks"]};
+  localparam int unsigned TCDMSize = NrBanks * TCDMDepth * (NarrowDataWidth/8);
+  localparam int unsigned TCDMAddrWidth = $clog2(TCDMSize);
+
+  // clock and resets
+  logic clk_i;
+  logic rst_ni;
+
+  // ports from accelerator to streamer
+% for idx, dw in enumerate(cfg["fifoWriterParams"]['fifoWidth']):
+  logic [${dw-1}:0] acc2stream_data_${idx}_bits_i;
+  logic acc2stream_data_${idx}_valid_i;
+  logic acc2stream_data_${idx}_ready_o;
+
+% endfor
+  // ports from streamer to accelerator
+% for idx, dw in enumerate(cfg["fifoReaderParams"]['fifoWidth']):
+  logic [${dw-1}:0] stream2acc_data_${idx}_bits_o;
+  logic stream2acc_data_${idx}_valid_o;
+  logic stream2acc_data_${idx}_ready_i;
+
+% endfor
+  //-----------------------------
+  // CSR control ports
+  //-----------------------------
+  // Request
+  logic [31:0] io_csr_req_bits_data_i;
+  logic [${csr_width-1}:0] io_csr_req_bits_addr_i;
+  logic io_csr_req_bits_write_i;
+  logic io_csr_req_valid_i;
+  logic io_csr_req_ready_o;
+
+  // Response
+  logic io_csr_rsp_ready_i;
+  logic io_csr_rsp_valid_o;
+  logic [31:0] io_csr_rsp_bits_data_o;
+
+  //-----------------------------
+  // TCDM ports
+  //-----------------------------
+  // Request
+  logic [TCDMReqPorts-1:0] tcdm_req_write;
+  logic [TCDMReqPorts-1:0][TCDMAddrWidth-1:0] tcdm_req_addr;
+  logic [TCDMReqPorts-1:0][3:0] tcdm_req_amo; 
+  logic [TCDMReqPorts-1:0][NarrowDataWidth-1:0] tcdm_req_data;
+  logic [TCDMReqPorts-1:0][4:0] tcdm_req_user_core_id; 
+  logic [TCDMReqPorts-1:0] tcdm_req_user_is_core;
+  logic [TCDMReqPorts-1:0][NarrowDataWidth/8-1:0] tcdm_req_strb;
+  logic [TCDMReqPorts-1:0] tcdm_req_q_valid;
+  // Response
+  logic [TCDMReqPorts-1:0] tcdm_rsp_q_ready;
+  logic [TCDMReqPorts-1:0] tcdm_rsp_p_valid;
+  logic [TCDMReqPorts-1:0][NarrowDataWidth-1:0] tcdm_rsp_data;
+
+  // These mon_* signals are seen by cocotb
+  // These are meant as montiring wires to tap into contents
+  logic [0:0] mon_tcdm_req_write_o [TCDMReqPorts-1:0];
+  logic [TCDMAddrWidth-1:0] mon_tcdm_req_addr_o [TCDMReqPorts-1:0];
+  logic [3:0] mon_tcdm_req_amo_o [TCDMReqPorts-1:0]; 
+  logic [NarrowDataWidth-1:0] mon_tcdm_req_data_o [TCDMReqPorts-1:0];
+  logic [4:0] mon_tcdm_req_user_core_id_o [TCDMReqPorts-1:0]; 
+  logic [0:0] mon_tcdm_req_user_is_core_o [TCDMReqPorts-1:0];
+  logic [NarrowDataWidth/8-1:0] mon_tcdm_req_strb_o [TCDMReqPorts-1:0];
+  logic [0:0] mon_tcdm_req_q_valid_o [TCDMReqPorts-1:0];
+  // Response
+  logic [0:0] mon_tcdm_rsp_q_ready_i [TCDMReqPorts-1:0];
+  logic [0:0] mon_tcdm_rsp_p_valid_i [TCDMReqPorts-1:0];
+  logic [NarrowDataWidth-1:0] mon_tcdm_rsp_data_i [TCDMReqPorts-1:0];
+
+  // Hard re-mapping just to handle the cocotb verilator translation
+  always_comb begin
+    for(int i = 0; i < TCDMReqPorts; i++) begin
+      mon_tcdm_req_write_o[i] = tcdm_req_write[i];
+      mon_tcdm_req_addr_o[i] = tcdm_req_addr[i];
+      mon_tcdm_req_amo_o[i] = tcdm_req_amo[i];
+      mon_tcdm_req_data_o[i] = tcdm_req_data[i];
+      mon_tcdm_req_user_core_id_o[i] = tcdm_req_user_core_id[i];
+      mon_tcdm_req_user_is_core_o[i] = tcdm_req_user_is_core[i];
+      mon_tcdm_req_strb_o[i] = tcdm_req_strb[i];
+      mon_tcdm_req_q_valid_o[i] = tcdm_req_q_valid[i];
+      mon_tcdm_rsp_data_i[i] = tcdm_rsp_data[i];
+      mon_tcdm_rsp_q_ready_i[i] = tcdm_rsp_q_ready[i];
+      mon_tcdm_rsp_p_valid_i[i] = tcdm_rsp_p_valid[i];
+    end
+  end
+
+  logic tcdm_dma_req_write_i;
+  logic [TCDMAddrWidth-1:0] tcdm_dma_req_addr_i;
+  logic [WideDataWidth-1:0] tcdm_dma_req_data_i;
+  logic [WideDataWidth/8-1:0] tcdm_dma_req_strb_i;
+  logic tcdm_dma_req_q_valid_i;
+  logic tcdm_dma_rsp_q_ready_o;
+  logic tcdm_dma_rsp_p_valid_o;
+  logic [WideDataWidth-1:0] tcdm_dma_rsp_data_o;
+
+  // TCDM subsystem
+  tcdm_subsys #(
+    .NarrowDataWidth ( NarrowDataWidth ),
+    .TCDMDepth ( TCDMDepth ),
+    .TCDMAddrWidth ( TCDMAddrWidth ),
+    .NrBanks ( NrBanks ),
+    .NumInp ( TCDMReqPorts )
+  ) i_tcdm_subsys (
+    //-----------------------------
+    // Clock and reset
+    //-----------------------------
+    .clk_i ( clk_i ),
+    .rst_ni ( rst_ni ),
+    //-----------------------------
+    // TCDM ports
+    //-----------------------------
+    .tcdm_req_write_i ( tcdm_req_write ),
+    .tcdm_req_addr_i ( tcdm_req_addr ),
+    .tcdm_req_amo_i ( tcdm_req_amo ),
+    .tcdm_req_data_i ( tcdm_req_data ),
+    .tcdm_req_user_core_id_i ( tcdm_req_user_core_id ),
+    .tcdm_req_user_is_core_i ( tcdm_req_user_is_core ),
+    .tcdm_req_strb_i ( tcdm_req_strb ),
+    .tcdm_req_q_valid_i ( tcdm_req_q_valid ),
+    .tcdm_rsp_q_ready_o ( tcdm_rsp_q_ready ),
+    .tcdm_rsp_p_valid_o ( tcdm_rsp_p_valid ),
+    .tcdm_rsp_data_o ( tcdm_rsp_data ),
+    //-----------------------------
+    // Wide TCDM ports
+    //-----------------------------
+    .tcdm_dma_req_write_i ( tcdm_dma_req_write_i ),
+    .tcdm_dma_req_addr_i ( tcdm_dma_req_addr_i ),
+    .tcdm_dma_req_data_i ( tcdm_dma_req_data_i ),
+    .tcdm_dma_req_strb_i ( tcdm_dma_req_strb_i ),
+    .tcdm_dma_req_q_valid_i ( tcdm_dma_req_q_valid_i ),
+    .tcdm_dma_rsp_q_ready_o ( tcdm_dma_rsp_q_ready_o ),
+    .tcdm_dma_rsp_p_valid_o ( tcdm_dma_rsp_p_valid_o ),
+    .tcdm_dma_rsp_data_o ( tcdm_dma_rsp_data_o )
+  );
+
+  streamer_wrapper #(
+    .NarrowDataWidth ( NarrowDataWidth ),
+    .TCDMDepth ( TCDMDepth ),
+    .TCDMReqPorts ( TCDMReqPorts ),
+    .TCDMSize ( TCDMSize ),
+    .TCDMAddrWidth ( TCDMAddrWidth )
+  ) i_streamer_wrapper (
+    //-----------------------------
+    // Clocks and reset
+    //-----------------------------
+    .clk_i ( clk_i ),
+    .rst_ni ( rst_ni ),
+
+    //-----------------------------
+    // Accelerator ports
+    //-----------------------------
+    // ports from acclerator to streamer
+% for idx, dw in enumerate(cfg["fifoWriterParams"]['fifoWidth']):
+    .acc2stream_data_${idx}_bits_i ( acc2stream_data_${idx}_bits_i ),
+    .acc2stream_data_${idx}_valid_i ( acc2stream_data_${idx}_valid_i ),
+    .acc2stream_data_${idx}_ready_o ( acc2stream_data_${idx}_ready_o ),
+
+% endfor
+    // ports from streamer to accelerator
+% for idx, dw in enumerate(cfg["fifoReaderParams"]['fifoWidth']):
+    .stream2acc_data_${idx}_bits_o ( stream2acc_data_${idx}_bits_o ),
+    .stream2acc_data_${idx}_valid_o ( stream2acc_data_${idx}_valid_o ),
+    .stream2acc_data_${idx}_ready_i ( stream2acc_data_${idx}_ready_i ),
+
+% endfor
+    //-----------------------------
+    // TCDM ports
+    //-----------------------------
+    // Request
+    .tcdm_req_write_o ( tcdm_req_write ),
+    .tcdm_req_addr_o ( tcdm_req_addr ),
+    .tcdm_req_amo_o ( tcdm_req_amo ), 
+    .tcdm_req_data_o ( tcdm_req_data ),
+    .tcdm_req_user_core_id_o ( tcdm_req_user_core_id ), 
+    .tcdm_req_user_is_core_o ( tcdm_req_user_is_core ),
+    .tcdm_req_strb_o ( tcdm_req_strb ),
+    .tcdm_req_q_valid_o ( tcdm_req_q_valid ),
+    // Response
+    .tcdm_rsp_q_ready_i ( tcdm_rsp_q_ready ),
+    .tcdm_rsp_p_valid_i ( tcdm_rsp_p_valid ),
+    .tcdm_rsp_data_i ( tcdm_rsp_data ),
+
+    //-----------------------------
+    // CSR control ports
+    //-----------------------------
+    // Request
+    .io_csr_req_bits_data_i ( io_csr_req_bits_data_i ),
+    .io_csr_req_bits_addr_i ( io_csr_req_bits_addr_i ),
+    .io_csr_req_bits_write_i ( io_csr_req_bits_write_i ),
+    .io_csr_req_valid_i ( io_csr_req_valid_i ),
+    .io_csr_req_ready_o ( io_csr_req_ready_o ),
+    // Response
+    .io_csr_rsp_ready_i ( io_csr_rsp_ready_i ),
+    .io_csr_rsp_valid_o ( io_csr_rsp_valid_o ),
+    .io_csr_rsp_bits_data_o ( io_csr_rsp_bits_data_o )
+  );
+
+endmodule


### PR DESCRIPTION
This PR adds a test that combines the TCDM and streamer. The test is as follows:

1. Load data through DMA ports first and double check if the data are correct
2. Configure streamer CSRs
3. Read data through the reader ports of the streamer. Also, verify the data at this step.
4. Write data using the streamer port.
5. Read the written data from step 4.

We add the following modifications:
- Template for the TCDM-streamer testbench
- Add wide data repacking function in `snax_util.py`
- Add TCDM-streamer test
- Add a wide data width parameter in the configuration file
- Re-factor `Makefile`