### PR TITLE
Add simple streaming multiplier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,11 @@ STREAM_TPL_RTL_FILENAME ?= streamer_wrapper.sv.tpl
 STREAM_TPL_SCALA_FILENAME ?= StreamParamGen.scala.tpl
 STREAM_TPL_TB_FILENAME ?= tb_streamer_top.sv.tpl
 STREAM_TCDM_TPL_TB_FILENAME ?= tb_stream_tcdm_top.sv.tpl
+STREAM_MUL_TPL_TB_FILENAME ?= tb_stream_mul.sv.tpl
+STREAM_MUL_TPL_RTL_FILENAME ?= stream_mul_wrapper.sv.tpl
 
 STREAM_WRAPPER_FILENAME ?= streamer_wrapper.sv
+STREAM_MUL_WRAPPER_FILENAME ?= stream_mul_wrapper.sv
 
 STREAM_SCALA_PARAM_FILENAME ?= StreamParamGen.scala
 
@@ -22,80 +25,101 @@ STREAM_TOP_FILENAME ?= StreamerTop.sv
 
 STREAM_TB_FILENAME ?= tb_streamer_top.sv
 STREAM_TCDM_TB_FILENAME ?= tb_stream_tcdm_top.sv
+STREAM_MUL_TB_FILENAME ?= tb_stream_mul.sv
 
 #-----------------------------
 # Default Path Declarations 
 #-----------------------------
 SNAX_STREAMER_PATH = $(shell $(BENDER) path snax-streamer)
-STREAM_CFG_PATH ?= ${CURDIR}/util/cfg
-STREAM_TPL_PATH ?= ${CURDIR}/util/templates
-STREAM_OUT_RTL_PATH ?= ${CURDIR}/rtl
-STREAM_OUT_TB_PATH ?= ${CURDIR}/tests/tb
+CFG_PATH ?= ${CURDIR}/util/cfg
+TPL_PATH ?= ${CURDIR}/util/templates
+RTL_PATH ?= ${CURDIR}/rtl
+TB_PATH ?= ${CURDIR}/tests/tb
 STREAM_OUT_SCALA_PATH ?= ${SNAX_STREAMER_PATH}/src/main/scala/streamer
-STREAM_OUT_TOP_PATH ?= ${STREAM_OUT_RTL_PATH}
 
 #-----------------------------
 # Default Path and File Declarations
 #-----------------------------
-STREAM_GEN_CFG_FILE = ${STREAM_CFG_PATH}/${STREAM_CFG_FILENAME}
+STREAM_GEN_CFG_FILE = ${CFG_PATH}/${STREAM_CFG_FILENAME}
 
-STREAM_GEN_TPL_RTL_FILE = ${STREAM_TPL_PATH}/${STREAM_TPL_RTL_FILENAME}
-STREAM_GEN_TPL_TB_FILE = ${STREAM_TPL_PATH}/${STREAM_TPL_TB_FILENAME}
-STREAM_TCDM_GEN_TPL_TB_FILE = ${STREAM_TPL_PATH}/${STREAM_TCDM_TPL_TB_FILENAME}
-STREAM_GEN_TPL_SCALA_FILE = ${STREAM_TPL_PATH}/${STREAM_TPL_SCALA_FILENAME}
+STREAM_GEN_TPL_RTL_FILE = ${TPL_PATH}/${STREAM_TPL_RTL_FILENAME}
+STREAM_MUL_TPL_RTL_FILE = ${TPL_PATH}/${STREAM_MUL_TPL_RTL_FILENAME}
+
+STREAM_GEN_TPL_SCALA_FILE = ${TPL_PATH}/${STREAM_TPL_SCALA_FILENAME}
+
+STREAM_GEN_TPL_TB_FILE = ${TPL_PATH}/${STREAM_TPL_TB_FILENAME}
+STREAM_TCDM_GEN_TPL_TB_FILE = ${TPL_PATH}/${STREAM_TCDM_TPL_TB_FILENAME}
+STREAM_MUL_GEN_TPL_TB_FILE = ${TPL_PATH}/${STREAM_MUL_TPL_TB_FILENAME}
 
 STREAM_GEN_OUT_SCALA_FILE = ${STREAM_OUT_SCALA_PATH}/${STREAM_SCALA_PARAM_FILENAME}
 
-STREAM_GEN_OUT_RTL_FILE = $(STREAM_OUT_RTL_PATH)/${STREAM_WRAPPER_FILENAME}
+STREAM_GEN_OUT_RTL_FILE = $(RTL_PATH)/${STREAM_WRAPPER_FILENAME}
+STREAM_MUL_OUT_RTL_FILE = $(RTL_PATH)/${STREAM_MUL_WRAPPER_FILENAME}
 
-STREAM_GEN_OUT_TOP_FILE = $(STREAM_OUT_TOP_PATH)/${STREAM_TOP_FILENAME}
+STREAM_GEN_OUT_TOP_FILE = $(RTL_PATH)/${STREAM_TOP_FILENAME}
 
-STREAM_GEN_OUT_TB_FILE = $(STREAM_OUT_TB_PATH)/${STREAM_TB_FILENAME}
-STREAM_TCDM_GEN_OUT_TB_FILE = $(STREAM_OUT_TB_PATH)/${STREAM_TCDM_TB_FILENAME}
+STREAM_GEN_OUT_TB_FILE = $(TB_PATH)/${STREAM_TB_FILENAME}
+STREAM_TCDM_GEN_OUT_TB_FILE = $(TB_PATH)/${STREAM_TCDM_TB_FILENAME}
+STREAM_MUL_GEN_OUT_TB_FILE = $(TB_PATH)/${STREAM_MUL_TB_FILENAME}
+
+#-----------------------------
+# Useful function
+#-----------------------------
+define generate_file
+	${PYTHON} util/scripts/template_gen.py --cfg_path="$(1)" \
+	--tpl_path="$(2)" \
+	--out_path="$(3)"
+endef
 
 #-----------------------------
 # Generate Streamer Scala Parameter
 #-----------------------------
 $(STREAM_GEN_OUT_SCALA_FILE):
-	${PYTHON} util/scripts/template_gen.py --cfg_path="${STREAM_GEN_CFG_FILE}" \
-	--tpl_path="${STREAM_GEN_TPL_SCALA_FILE}" \
-	--out_path="${STREAM_GEN_OUT_SCALA_FILE}"
+	$(call generate_file,${STREAM_GEN_CFG_FILE},${STREAM_GEN_TPL_SCALA_FILE},${STREAM_GEN_OUT_SCALA_FILE})
 
 #-----------------------------
 # Generate StreamTop.sv
 #-----------------------------
 $(STREAM_GEN_OUT_TOP_FILE):
 	cd ${SNAX_STREAMER_PATH} && \
-	sbt "runMain streamer.StreamerTopGen ${STREAM_OUT_TOP_PATH}"
+	sbt "runMain streamer.StreamerTopGen ${RTL_PATH}"
 	@echo "Generates output: ${STREAM_GEN_OUT_TOP_FILE}"
 
 #-----------------------------
 # Generate tb_stream_top.sv
 #-----------------------------
 $(STREAM_GEN_OUT_RTL_FILE):
-	${PYTHON} util/scripts/template_gen.py --cfg_path="${STREAM_GEN_CFG_FILE}" \
-	--tpl_path="${STREAM_GEN_TPL_RTL_FILE}" \
-	--out_path="${STREAM_GEN_OUT_RTL_FILE}"
+	$(call generate_file,${STREAM_GEN_CFG_FILE},${STREAM_GEN_TPL_RTL_FILE},${STREAM_GEN_OUT_RTL_FILE})
 
 #-----------------------------
 # Generate Streamer Wrapper Testbench
 #-----------------------------
 ${STREAM_GEN_OUT_TB_FILE}:	$(STREAM_GEN_OUT_SCALA_FILE) $(STREAM_GEN_OUT_TOP_FILE) $(STREAM_GEN_OUT_RTL_FILE)
-	${PYTHON} util/scripts/template_gen.py --cfg_path="${STREAM_GEN_CFG_FILE}" \
-	--tpl_path="${STREAM_GEN_TPL_TB_FILE}" \
-	--out_path="${STREAM_GEN_OUT_TB_FILE}"
+	$(call generate_file,${STREAM_GEN_CFG_FILE},${STREAM_GEN_TPL_TB_FILE},${STREAM_GEN_OUT_TB_FILE})
 
 #-----------------------------
 # Generate Streamer-TCDM Wrapper Testbench
 #-----------------------------
 ${STREAM_TCDM_GEN_OUT_TB_FILE}:	$(STREAM_GEN_OUT_SCALA_FILE) $(STREAM_GEN_OUT_TOP_FILE) $(STREAM_GEN_OUT_RTL_FILE)
-	${PYTHON} util/scripts/template_gen.py --cfg_path="${STREAM_GEN_CFG_FILE}" \
-	--tpl_path="${STREAM_TCDM_GEN_TPL_TB_FILE}" \
-	--out_path="${STREAM_TCDM_GEN_OUT_TB_FILE}"
+	$(call generate_file,${STREAM_GEN_CFG_FILE},${STREAM_TCDM_GEN_TPL_TB_FILE},${STREAM_TCDM_GEN_OUT_TB_FILE})
+
+#-----------------------------
+# Generate Stream-mul Wrapper
+#-----------------------------
+$(STREAM_MUL_OUT_RTL_FILE):
+	$(call generate_file,${STREAM_GEN_CFG_FILE},${STREAM_MUL_TPL_RTL_FILE},${STREAM_MUL_OUT_RTL_FILE})
+
+#-----------------------------
+# Generate Streamer-MUL Wrapper Testbench
+#-----------------------------
+${STREAM_MUL_GEN_OUT_TB_FILE}: $(STREAM_GEN_OUT_SCALA_FILE) $(STREAM_GEN_OUT_TOP_FILE) $(STREAM_GEN_OUT_RTL_FILE) $(STREAM_MUL_OUT_RTL_FILE)
+	$(call generate_file,${STREAM_GEN_CFG_FILE},${STREAM_MUL_GEN_TPL_TB_FILE},${STREAM_MUL_GEN_OUT_TB_FILE})
 
 #-----------------------------
 # Clean
 #-----------------------------
 clean:
 	rm -f ${STREAM_GEN_OUT_RTL_FILE} ${STREAM_GEN_OUT_SCALA_FILE} \
-	${STREAM_GEN_OUT_TOP_FILE} ${STREAM_GEN_OUT_TB_FILE} ${STREAM_TCDM_GEN_OUT_TB_FILE}
+	${STREAM_GEN_OUT_TOP_FILE} ${STREAM_GEN_OUT_TB_FILE} \
+	${STREAM_TCDM_GEN_OUT_TB_FILE} ${STREAM_MUL_OUT_RTL_FILE} \
+	${STREAM_MUL_GEN_OUT_TB_FILE}

--- a/rtl/simple-mul/simple_mul.sv
+++ b/rtl/simple-mul/simple_mul.sv
@@ -1,0 +1,66 @@
+//-------------------------------
+// Simple multiplier that follows
+// the valid-ready responses per port
+//-------------------------------
+module simple_mul #(
+  parameter int unsigned DataWidth = 64
+)(
+  input  logic                 clk_i,
+  input  logic                 rst_ni,
+  input  logic [DataWidth-1:0] a_i,
+  input  logic                 a_valid_i,
+  output logic                 a_ready_o,
+  input  logic [DataWidth-1:0] b_i,
+  input  logic                 b_valid_i,
+  output logic                 b_ready_o,
+  output logic [DataWidth-1:0] result_o,
+  output logic                 result_valid_o,
+  input  logic                 result_ready_i
+);
+
+  //-------------------------------
+  // Wires and combinationa logic
+  //-------------------------------
+  logic [2*DataWidth-1:0] result_wide;
+
+  logic input_success;
+  logic output_success;
+
+  logic result_success;
+  logic result_valid;
+
+  assign input_success  = a_valid_i && b_valid_i;
+  assign output_success = result_valid_o && result_ready_i;
+
+  //-------------------------------
+  // Registered output
+  //-------------------------------
+  always_ff @ (posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      result_wide  <= {DataWidth{1'b0}};
+      result_valid <= 1'b0;
+    end else begin
+      if(input_success) begin
+        result_wide  <= a_i * b_i;
+        result_valid <= 1'b1;
+      end else if (output_success) begin
+        result_wide  <= {DataWidth{1'b0}};
+        result_valid <= 1'b0;
+      end else begin
+        result_wide  <= result_wide;
+        result_valid <= result_valid;
+      end
+    end
+  end
+
+  //-------------------------------
+  // Assignments
+  //-------------------------------
+  // Input ports are ready when the output
+  // Is actually ready to get data
+  assign a_ready_o      = input_success;
+  assign b_ready_o      = input_success;
+  assign result_valid_o = result_valid;
+  assign result_o       = result_wide[DataWidth-1:0];
+
+endmodule

--- a/rtl/simple-mul/simple_mul_wrapper.sv
+++ b/rtl/simple-mul/simple_mul_wrapper.sv
@@ -1,0 +1,69 @@
+//-------------------------------
+// Simple multiplier that follows
+// the valid-ready responses per port
+//-------------------------------
+module simple_mul_wrapper #(
+  parameter int unsigned SpatPar = 4,
+  parameter int unsigned DataWidth = 64
+)(
+  input  logic                           clk_i,
+  input  logic                           rst_ni,
+  input  logic [(SpatPar*DataWidth)-1:0] a_i,
+  input  logic                           a_valid_i,
+  output logic                           a_ready_o,
+  input  logic [(SpatPar*DataWidth)-1:0] b_i,
+  input  logic                           b_valid_i,
+  output logic                           b_ready_o,
+  output logic [(SpatPar*DataWidth)-1:0] result_o,
+  output logic                           result_valid_o,
+  input  logic                           result_ready_i
+);
+
+  //-------------------------------
+  // Wires and combinationa logic
+  //-------------------------------
+  logic [SpatPar-1:0][DataWidth-1:0] a_split;
+  logic [SpatPar-1:0][DataWidth-1:0] b_split;
+  logic [SpatPar-1:0][DataWidth-1:0] result_split;
+
+  logic [SpatPar-1:0] a_ready;
+  logic [SpatPar-1:0] b_ready;
+  logic [SpatPar-1:0] result_valid;
+
+  //-------------------------------
+  // Flexible mapping
+  //-------------------------------
+  always_comb begin
+    for (int i = 0; i < SpatPar; i++) begin
+      a_split[i] = a_i[i*DataWidth+:DataWidth];
+      b_split[i] = b_i[i*DataWidth+:DataWidth];
+      result_o[i*DataWidth+:DataWidth] = result_split[i];
+    end
+
+    a_ready_o = &a_ready;
+    b_ready_o = &b_ready;
+    result_valid_o = &result_valid;
+  end
+
+  //-------------------------------
+  // Generate Simple Multipliers
+  //-------------------------------
+  for (genvar i = 0; i < SpatPar; i ++) begin: gen_spatpar_muls
+    simple_mul #(
+      .DataWidth      ( DataWidth       )
+    ) i_simple_mul (
+      .clk_i          ( clk_i           ),
+      .rst_ni         ( rst_ni          ),
+      .a_i            ( a_split[i]      ),
+      .a_valid_i      ( a_valid_i       ),
+      .a_ready_o      ( a_ready[i]      ),
+      .b_i            ( b_split[i]      ),
+      .b_valid_i      ( b_valid_i       ),
+      .b_ready_o      ( b_ready[i]      ),
+      .result_o       ( result_split[i] ),
+      .result_valid_o ( result_valid[i] ),
+      .result_ready_i ( result_ready_i  )
+    );
+  end
+
+endmodule

--- a/tests/cocotb/test_stream_mul.py
+++ b/tests/cocotb/test_stream_mul.py
@@ -1,0 +1,309 @@
+# ---------------------------------
+# Copyright 2024 KULeuven
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+# Author: Ryan Antonio (ryan.antonio@esat.kuleuven.be)
+#
+# Description:
+# This test is a complete set where the TCDM subsystem,
+# SNAX streamer, and a dummy accelerator are connected together.
+# The dummy accelerator is a simple multiply streamer.
+#
+# Sequence of tests:
+# 1. Load data through DMA
+# 2. Set the streamer CSRs
+# 3. Check the output of the streamer
+# ---------------------------------
+
+import cocotb
+from cocotb.triggers import RisingEdge, Timer
+from cocotb.clock import Clock
+from cocotb_test.simulator import run
+import snax_util
+import os
+import subprocess
+from decimal import Decimal
+
+from tests.cocotb.test_tcdm_subsys import MAX_VAL
+
+
+# Configurable testing parameters
+# In the default value below, the number
+# of tests fills the entire memory
+NARROW_DATA_WIDTH = 64
+WIDE_DATA_WIDTH = 512
+TCDM_DEPTH = 64
+NR_BANKS = 32
+SPATPAR = 4
+BANK_INCREMENT = int(NARROW_DATA_WIDTH / 8)
+WIDE_BANK_INCREMENT = int(WIDE_DATA_WIDTH / 8)
+WIDE_NARROW_RATIO = int(WIDE_DATA_WIDTH / NARROW_DATA_WIDTH)
+NUM_NARROW_TESTS = TCDM_DEPTH * NR_BANKS
+NUM_WIDE_TESTS = int(NUM_NARROW_TESTS / 8)
+MIN_VAL = 0
+MAX_NARROW_VAL = 2**NARROW_DATA_WIDTH
+MAX_WIDE_VAL = 2**WIDE_DATA_WIDTH
+
+# DON'T TOUCH ME PLEASE
+# CSR parameters from the default
+# Configuration found under util/cfg/streamer_cfg.hjson
+# Also some pre-computed that are fixed
+CSR_LOOP_COUNT_0 = 0
+CSR_TEMPORAL_STRIDE_0 = 1
+CSR_TEMPORAL_STRIDE_1 = 2
+CSR_TEMPORAL_STRIDE_2 = 3
+CSR_SPATIAL_STRIDE_0 = 4
+CSR_SPATIAL_STRIDE_1 = 5
+CSR_SPATIAL_STRIDE_2 = 6
+CSR_BASE_PTR_0 = 7
+CSR_BASE_PTR_1 = 8
+CSR_BASE_PTR_2 = 9
+CSR_START_STREAMER = 10
+
+
+@cocotb.test()
+async def stream_tcdm_dut(dut):
+    # Value configurations you can set
+    # For exploration and testing
+    # These values go into the respective
+    # CSR register addresses above
+    LOOP_COUNT_0 = 100
+    TEMPORAL_STRIDE_0 = 64
+    TEMPORAL_STRIDE_1 = 64
+    TEMPORAL_STRIDE_2 = 64
+    SPATIAL_STRIDE_0 = 8
+    SPATIAL_STRIDE_1 = 8
+    SPATIAL_STRIDE_2 = 8
+    BASE_PTR_0 = 0
+    BASE_PTR_1 = 32
+    BASE_PTR_2 = 64
+
+    # Start clock
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start())
+
+    # Initial reset values
+    # Need to clear for modelsim (or other simulator)
+    # Verilator assumes 0, no don't care states
+    dut.rst_ni.value = 0
+
+    # Always active assuming core can
+    # contiuously read data from streamer CSR
+    dut.io_csr_rsp_ready_i.value = 1
+
+    # Set DMA ports to 0 first before driving
+    dut.tcdm_dma_req_write_i.value = 0
+    dut.tcdm_dma_req_addr_i.value = 0
+    dut.tcdm_dma_req_data_i.value = 0
+    dut.tcdm_dma_req_strb_i.value = 0
+    dut.tcdm_dma_req_q_valid_i.value = 0
+
+    await snax_util.clock_and_wait(dut)
+
+    # Release reset
+    dut.rst_ni.value = 1
+
+    await snax_util.clock_and_wait(dut)
+
+    # Preload data into the TCDM subsys
+    # using the DMA ports
+    cocotb.log.info("Preload data with DMA control")
+
+    # Generate data to be processed
+    # Number of elements is dependent on:
+    # LOOP_COUNT_0 x (WIDE_DATA_WIDTH / NARROW_DATA_WIDTH)
+    narrow_golden_list = snax_util.gen_rand_int_list(
+        int(LOOP_COUNT_0 * (WIDE_DATA_WIDTH / NARROW_DATA_WIDTH)), MIN_VAL, MAX_VAL
+    )
+    wide_golden_list = snax_util.gen_wide_list(
+        narrow_golden_list, NARROW_DATA_WIDTH, WIDE_DATA_WIDTH
+    )
+
+    # Precompute golden results
+    narrow_golden_result = []
+
+    for i in range(LOOP_COUNT_0):
+        for j in range(SPATPAR):
+            temp_res = (
+                narrow_golden_list[i * SPATPAR * 2 + j]
+                * narrow_golden_list[(2 * i + 1) * SPATPAR + j]
+            )
+            temp_res = temp_res & (MAX_NARROW_VAL - 1)
+            narrow_golden_result.append(temp_res)
+
+    wide_golden_result = snax_util.gen_wide_list(
+        narrow_golden_result, NARROW_DATA_WIDTH, (NARROW_DATA_WIDTH * SPATPAR)
+    )
+
+    # Preload TCDM DMA subsys using DMA ports
+    wide_len = len(wide_golden_list)
+    for i in range(wide_len):
+        await snax_util.wide_tcdm_write(
+            dut, i * WIDE_BANK_INCREMENT, wide_golden_list[i]
+        )
+
+    await snax_util.wide_tcdm_clr(dut)
+
+    # Sanity check contents loaded into DMA
+    for i in range(wide_len):
+        tcdm_wide_val = await snax_util.wide_tcdm_read(dut, i * WIDE_BANK_INCREMENT)
+        snax_util.comp_and_assert(wide_golden_list[i], tcdm_wide_val)
+
+    await snax_util.wide_tcdm_clr(dut)
+
+    cocotb.log.info("Setting up of CSR registers and verifying if setup is correct")
+
+    # At this point we'll do explicit declartion
+    # of the tests so that it's understandable
+    # for other users
+
+    # Set number of iterations
+    await snax_util.reg_write(dut, CSR_LOOP_COUNT_0, LOOP_COUNT_0)
+
+    # Set temporal strides
+    await snax_util.reg_write(dut, CSR_TEMPORAL_STRIDE_0, TEMPORAL_STRIDE_0)
+    await snax_util.reg_write(dut, CSR_TEMPORAL_STRIDE_1, TEMPORAL_STRIDE_1)
+    await snax_util.reg_write(dut, CSR_TEMPORAL_STRIDE_2, TEMPORAL_STRIDE_2)
+
+    # Set spatial strides
+    await snax_util.reg_write(dut, CSR_SPATIAL_STRIDE_0, SPATIAL_STRIDE_0)
+    await snax_util.reg_write(dut, CSR_SPATIAL_STRIDE_1, SPATIAL_STRIDE_1)
+    await snax_util.reg_write(dut, CSR_SPATIAL_STRIDE_2, SPATIAL_STRIDE_2)
+
+    # Set base pointers
+    await snax_util.reg_write(dut, CSR_BASE_PTR_0, BASE_PTR_0)
+    await snax_util.reg_write(dut, CSR_BASE_PTR_1, BASE_PTR_1)
+    await snax_util.reg_write(dut, CSR_BASE_PTR_2, BASE_PTR_2)
+
+    # Clear driver signals
+    # So that we don't have stuck valid
+    await snax_util.reg_clr(dut)
+
+    # Read and verify the contents
+    # of the previously set registers
+    reg_val = await snax_util.reg_read(dut, CSR_LOOP_COUNT_0)
+    snax_util.comp_and_assert(LOOP_COUNT_0, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_TEMPORAL_STRIDE_0)
+    snax_util.comp_and_assert(TEMPORAL_STRIDE_0, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_TEMPORAL_STRIDE_1)
+    snax_util.comp_and_assert(TEMPORAL_STRIDE_1, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_TEMPORAL_STRIDE_2)
+    snax_util.comp_and_assert(TEMPORAL_STRIDE_2, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_SPATIAL_STRIDE_0)
+    snax_util.comp_and_assert(SPATIAL_STRIDE_0, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_SPATIAL_STRIDE_1)
+    snax_util.comp_and_assert(SPATIAL_STRIDE_1, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_SPATIAL_STRIDE_2)
+    snax_util.comp_and_assert(SPATIAL_STRIDE_2, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_BASE_PTR_0)
+    snax_util.comp_and_assert(BASE_PTR_0, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_BASE_PTR_1)
+    snax_util.comp_and_assert(BASE_PTR_1, reg_val)
+    reg_val = await snax_util.reg_read(dut, CSR_BASE_PTR_2)
+    snax_util.comp_and_assert(BASE_PTR_2, reg_val)
+    await snax_util.reg_clr(dut)
+
+    # In this test we simply continuously
+    # stream the data in the stream to accelerator ports
+    # and check if the data is consistent with the preloaded data
+    cocotb.log.info("Run the streamer and check if data are correct")
+
+    # Write anything to CSR_STAR_STREAMER CSR
+    # adderss to activate the streamer
+    await snax_util.reg_write(dut, CSR_START_STREAMER, 0)
+    await snax_util.reg_clr(dut)
+
+    # Wait for the rising edge of the valid
+    # From here we can continuously stream for ever clock cycle
+    await RisingEdge(dut.i_stream_mul_wrapper.acc2stream_data_0_valid)
+    # Necessary for cocotb evaluation step
+    await Timer(Decimal(1), units="ps")
+
+    for i in range(LOOP_COUNT_0):
+        # Extract the data
+        write_stream_0 = int(dut.i_stream_mul_wrapper.acc2stream_data_0_bits.value)
+
+        # Streamed data should be consistent
+        snax_util.comp_and_assert(wide_golden_result[i], write_stream_0)
+        await snax_util.clock_and_wait(dut)
+
+
+# Main test run
+def test_stream_mul(simulator, waves):
+    repo_path = os.getcwd()
+    tests_path = repo_path + "/tests/cocotb/"
+
+    # Make sure to generate the StreamerTop.sv
+    # If it does not exist
+    stream_mul_tb_file = repo_path + "/tests/tb/tb_stream_mul.sv"
+    if not os.path.exists(stream_mul_tb_file):
+        subprocess.run(["make", stream_mul_tb_file])
+
+    streamer_verilog_sources = [
+        repo_path + "/rtl/StreamerTop.sv",
+        repo_path + "/rtl/streamer_wrapper.sv",
+    ]
+
+    # Extract TCDM components
+    tcdm_includes, tcdm_verilog_sources = snax_util.extract_tcdm_list()
+
+    # Extract resources for simple mul
+    simple_mul_sources = [
+        repo_path + "/rtl/simple-mul/simple_mul.sv",
+        repo_path + "/rtl/simple-mul/simple_mul_wrapper.sv",
+        repo_path + "/rtl/stream_mul_wrapper.sv",
+    ]
+
+    tb_verilog_source = [
+        stream_mul_tb_file,
+    ]
+
+    verilog_sources = (
+        tcdm_verilog_sources
+        + streamer_verilog_sources
+        + simple_mul_sources
+        + tb_verilog_source
+    )
+
+    defines = []
+    includes = [] + tcdm_includes
+
+    toplevel = "tb_stream_mul"
+
+    module = "test_stream_mul"
+
+    sim_build = tests_path + "/sim_build/{}/".format(toplevel)
+
+    if simulator == "verilator":
+        compile_args = [
+            "-Wno-LITENDIAN",
+            "-Wno-WIDTH",
+            "-Wno-CASEINCOMPLETE",
+            "-Wno-BLKANDNBLK",
+            "-Wno-CMPCONST",
+            "-Wno-WIDTHCONCAT",
+            "-Wno-UNSIGNED",
+            "-Wno-UNOPTFLAT",
+            "-Wno-TIMESCALEMOD",
+            "-Wno-fatal",
+            "--no-timing",
+            "--trace",
+            "--trace-structs",
+        ]
+        timescale = None
+    else:
+        compile_args = None
+        timescale = "1ns/1ps"
+
+    run(
+        verilog_sources=verilog_sources,
+        includes=includes,
+        toplevel=toplevel,
+        defines=defines,
+        module=module,
+        simulator=simulator,
+        sim_build=sim_build,
+        compile_args=compile_args,
+        waves=waves,
+        timescale=timescale,
+    )

--- a/tests/tb/tb_tcdm_subsys.sv
+++ b/tests/tb/tb_tcdm_subsys.sv
@@ -78,7 +78,7 @@ module tb_tcdm_subsys #(
     .NarrowDataWidth          ( NarrowDataWidth       ),
     .TCDMDepth                ( TCDMDepth             ),
     .NrBanks                  ( NrBanks               ),
-    .NumInp                   ( NumInp                ),
+    .NumInp                   ( NumInp                )
   ) i_tcdm_subsys (
     //-----------------------------
     // Clock and reset

--- a/util/templates/stream_mul_wrapper.sv.tpl
+++ b/util/templates/stream_mul_wrapper.sv.tpl
@@ -1,0 +1,163 @@
+<%
+  import math
+
+  num_loop_dim = cfg["temporalAddrGenUnitParams"]["loopDim"]
+  num_data_mover = (len(cfg["dataReaderParams"]["tcdmPortsNum"]) + len(cfg["dataWriterParams"]["tcdmPortsNum"])) 
+  num_dmove_x_loop_dim = num_data_mover * num_loop_dim
+  num_spatial_dim = sum(cfg["dataReaderParams"]["spatialDim"]) + sum(cfg["dataWriterParams"]["spatialDim"])
+  
+  csr_num = num_loop_dim + num_dmove_x_loop_dim + num_data_mover + num_spatial_dim + 1
+  csr_width = math.ceil(math.log2(csr_num))
+%>
+//-------------------------------
+// Streamer-MUL wrapper
+// This is the entire accelerator
+// That connecst to the TCDM subsystem
+//-------------------------------
+module stream_mul_wrapper # (
+  parameter int unsigned NarrowDataWidth = ${cfg["tcdmDataWidth"]},
+  parameter int unsigned TCDMDepth = ${cfg["tcdmDepth"]},
+  parameter int unsigned TCDMReqPorts = ${sum(cfg["dataReaderParams"]["tcdmPortsNum"]) + sum(cfg["dataWriterParams"]["tcdmPortsNum"])},
+  parameter int unsigned TCDMSize = TCDMReqPorts * TCDMDepth * (NarrowDataWidth/8),
+  parameter int unsigned TCDMAddrWidth = $clog2(TCDMSize),
+  parameter int unsigned SpatPar = ${cfg["dataReaderParams"]["spatialBounds"][0][0]}
+)(
+  //-----------------------------
+  // Clocks and reset
+  //-----------------------------
+  input logic clk_i,
+  input logic rst_ni,
+
+  //-----------------------------
+  // TCDM ports
+  //-----------------------------
+  // Request
+  output logic [TCDMReqPorts-1:0] tcdm_req_write_o,
+  output logic [TCDMReqPorts-1:0][TCDMAddrWidth-1:0] tcdm_req_addr_o,
+  output logic [TCDMReqPorts-1:0][3:0] tcdm_req_amo_o, //Note that tcdm_req_amo_i is 4 bits based on reqrsp definition
+  output logic [TCDMReqPorts-1:0][NarrowDataWidth-1:0] tcdm_req_data_o,
+  output logic [TCDMReqPorts-1:0][4:0] tcdm_req_user_core_id_o, //Note that tcdm_req_user_core_id_i is 5 bits based on Snitch definition
+  output logic [TCDMReqPorts-1:0] tcdm_req_user_is_core_o,
+  output logic [TCDMReqPorts-1:0][NarrowDataWidth/8-1:0] tcdm_req_strb_o,
+  output logic [TCDMReqPorts-1:0] tcdm_req_q_valid_o,
+
+  // Response
+  input logic [TCDMReqPorts-1:0] tcdm_rsp_q_ready_i,
+  input logic [TCDMReqPorts-1:0] tcdm_rsp_p_valid_i,
+  input logic [TCDMReqPorts-1:0][NarrowDataWidth-1:0] tcdm_rsp_data_i,
+
+  //-----------------------------
+  // CSR control ports
+  //-----------------------------
+  // Request
+  input logic [31:0] io_csr_req_bits_data_i,
+  input logic [${csr_width-1}:0] io_csr_req_bits_addr_i,
+  input logic io_csr_req_bits_write_i,
+  input logic io_csr_req_valid_i,
+  output logic io_csr_req_ready_o,
+
+  // Response
+  input logic io_csr_rsp_ready_i,
+  output logic io_csr_rsp_valid_o,
+  output logic [31:0] io_csr_rsp_bits_data_o
+);
+
+  // ports from accelerator to streamer
+% for idx, dw in enumerate(cfg["fifoWriterParams"]['fifoWidth']):
+  logic [${dw-1}:0] acc2stream_data_${idx}_bits;
+  logic acc2stream_data_${idx}_valid;
+  logic acc2stream_data_${idx}_ready;
+
+% endfor
+  // ports from streamer to accelerator
+% for idx, dw in enumerate(cfg["fifoReaderParams"]['fifoWidth']):
+  logic [${dw-1}:0] stream2acc_data_${idx}_bits;
+  logic stream2acc_data_${idx}_valid;
+  logic stream2acc_data_${idx}_ready;
+
+% endfor
+
+  streamer_wrapper #(
+    .NarrowDataWidth ( NarrowDataWidth ),
+    .TCDMDepth ( TCDMDepth ),
+    .TCDMReqPorts ( TCDMReqPorts ),
+    .TCDMSize ( TCDMSize ),
+    .TCDMAddrWidth ( TCDMAddrWidth )
+  ) i_streamer_wrapper (
+    //-----------------------------
+    // Clocks and reset
+    //-----------------------------
+    .clk_i ( clk_i ),
+    .rst_ni ( rst_ni ),
+
+    //-----------------------------
+    // Accelerator ports
+    //-----------------------------
+    // ports from acclerator to streamer
+    .acc2stream_data_0_bits_i ( acc2stream_data_0_bits ),
+    .acc2stream_data_0_valid_i ( acc2stream_data_0_valid ),
+    .acc2stream_data_0_ready_o ( acc2stream_data_0_ready ),
+
+    // ports from streamer to accelerator
+    .stream2acc_data_0_bits_o ( stream2acc_data_0_bits ),
+    .stream2acc_data_0_valid_o ( stream2acc_data_0_valid ),
+    .stream2acc_data_0_ready_i ( stream2acc_data_0_ready ),
+
+    .stream2acc_data_1_bits_o ( stream2acc_data_1_bits ),
+    .stream2acc_data_1_valid_o ( stream2acc_data_1_valid ),
+    .stream2acc_data_1_ready_i ( stream2acc_data_1_ready ),
+
+    //-----------------------------
+    // TCDM ports
+    //-----------------------------
+    // Request
+    .tcdm_req_write_o ( tcdm_req_write_o ),
+    .tcdm_req_addr_o ( tcdm_req_addr_o ),
+    .tcdm_req_amo_o ( tcdm_req_amo_o ), 
+    .tcdm_req_data_o ( tcdm_req_data_o ),
+    .tcdm_req_user_core_id_o ( tcdm_req_user_core_id_o ), 
+    .tcdm_req_user_is_core_o ( tcdm_req_user_is_core_o ),
+    .tcdm_req_strb_o ( tcdm_req_strb_o ),
+    .tcdm_req_q_valid_o ( tcdm_req_q_valid_o ),
+    // Response
+    .tcdm_rsp_q_ready_i ( tcdm_rsp_q_ready_i ),
+    .tcdm_rsp_p_valid_i ( tcdm_rsp_p_valid_i ),
+    .tcdm_rsp_data_i ( tcdm_rsp_data_i ),
+
+    //-----------------------------
+    // CSR control ports
+    //-----------------------------
+    // Request
+    .io_csr_req_bits_data_i ( io_csr_req_bits_data_i ),
+    .io_csr_req_bits_addr_i ( io_csr_req_bits_addr_i ),
+    .io_csr_req_bits_write_i ( io_csr_req_bits_write_i ),
+    .io_csr_req_valid_i ( io_csr_req_valid_i ),
+    .io_csr_req_ready_o ( io_csr_req_ready_o ),
+    // Response
+    .io_csr_rsp_ready_i ( io_csr_rsp_ready_i ),
+    .io_csr_rsp_valid_o ( io_csr_rsp_valid_o ),
+    .io_csr_rsp_bits_data_o ( io_csr_rsp_bits_data_o )
+  );
+
+  //-----------------------------
+  // MUL Accelerator
+  //-----------------------------
+  simple_mul_wrapper #(
+    .SpatPar ( SpatPar ),
+    .DataWidth ( NarrowDataWidth )
+  ) i_simple_mul_wrapper (
+    .clk_i ( clk_i ),
+    .rst_ni ( rst_ni ),
+    .a_i ( stream2acc_data_0_bits ),
+    .a_valid_i ( stream2acc_data_0_valid),
+    .a_ready_o ( stream2acc_data_0_ready ),
+    .b_i ( stream2acc_data_1_bits ),
+    .b_valid_i ( stream2acc_data_1_valid ),
+    .b_ready_o ( stream2acc_data_1_ready ),
+    .result_o ( acc2stream_data_0_bits ),
+    .result_valid_o ( acc2stream_data_0_valid ),
+    .result_ready_i ( acc2stream_data_0_ready)
+  );
+
+
+endmodule

--- a/util/templates/streamer_wrapper.sv.tpl
+++ b/util/templates/streamer_wrapper.sv.tpl
@@ -16,7 +16,6 @@ module streamer_wrapper #(
   parameter int unsigned NarrowDataWidth = ${cfg["tcdmDataWidth"]},
   parameter int unsigned TCDMDepth = ${cfg["tcdmDepth"]},
   parameter int unsigned TCDMReqPorts = ${sum(cfg["dataReaderParams"]["tcdmPortsNum"]) + sum(cfg["dataWriterParams"]["tcdmPortsNum"])},
-  parameter int unsigned TCDMMemAddrWidth = $clog2(TCDMDepth),
   parameter int unsigned TCDMSize = TCDMReqPorts * TCDMDepth * (NarrowDataWidth/8),
   parameter int unsigned TCDMAddrWidth = $clog2(TCDMSize)
 )(

--- a/util/templates/tb_stream_mul.sv.tpl
+++ b/util/templates/tb_stream_mul.sv.tpl
@@ -1,0 +1,156 @@
+<%
+  import math
+
+  num_loop_dim = cfg["temporalAddrGenUnitParams"]["loopDim"]
+  num_data_mover = (len(cfg["dataReaderParams"]["tcdmPortsNum"]) + len(cfg["dataWriterParams"]["tcdmPortsNum"])) 
+  num_dmove_x_loop_dim = num_data_mover * num_loop_dim
+  num_spatial_dim = sum(cfg["dataReaderParams"]["spatialDim"]) + sum(cfg["dataWriterParams"]["spatialDim"])
+  
+  csr_num = num_loop_dim + num_dmove_x_loop_dim + num_data_mover + num_spatial_dim + 1
+  csr_width = math.ceil(math.log2(csr_num))
+%>
+//-----------------------------------
+// Basic SNAX streamer testbench
+//-----------------------------------
+module tb_stream_mul;
+
+  localparam int unsigned NarrowDataWidth = ${cfg["tcdmDataWidth"]};
+  localparam int unsigned WideDataWidth = ${cfg["tcdmDmaDataWidth"]};
+  localparam int unsigned TCDMDepth = ${cfg["tcdmDepth"]};
+  localparam int unsigned TCDMReqPorts = ${sum(cfg["dataReaderParams"]["tcdmPortsNum"]) + sum(cfg["dataWriterParams"]["tcdmPortsNum"])};
+  localparam int unsigned NrBanks = ${cfg["numBanks"]};
+  localparam int unsigned TCDMSize = NrBanks * TCDMDepth * (NarrowDataWidth/8);
+  localparam int unsigned TCDMAddrWidth = $clog2(TCDMSize);
+  localparam int unsigned SpatPar = ${cfg["dataReaderParams"]["spatialBounds"][0][0]};
+
+  // clock and resets
+  logic clk_i;
+  logic rst_ni;
+
+  //-----------------------------
+  // CSR control ports
+  //-----------------------------
+  // Request
+  logic [31:0] io_csr_req_bits_data_i;
+  logic [${csr_width-1}:0] io_csr_req_bits_addr_i;
+  logic io_csr_req_bits_write_i;
+  logic io_csr_req_valid_i;
+  logic io_csr_req_ready_o;
+
+  // Response
+  logic io_csr_rsp_ready_i;
+  logic io_csr_rsp_valid_o;
+  logic [31:0] io_csr_rsp_bits_data_o;
+
+  //-----------------------------
+  // TCDM ports
+  //-----------------------------
+  // Request
+  logic [TCDMReqPorts-1:0] tcdm_req_write;
+  logic [TCDMReqPorts-1:0][TCDMAddrWidth-1:0] tcdm_req_addr;
+  logic [TCDMReqPorts-1:0][3:0] tcdm_req_amo; 
+  logic [TCDMReqPorts-1:0][NarrowDataWidth-1:0] tcdm_req_data;
+  logic [TCDMReqPorts-1:0][4:0] tcdm_req_user_core_id; 
+  logic [TCDMReqPorts-1:0] tcdm_req_user_is_core;
+  logic [TCDMReqPorts-1:0][NarrowDataWidth/8-1:0] tcdm_req_strb;
+  logic [TCDMReqPorts-1:0] tcdm_req_q_valid;
+  // Response
+  logic [TCDMReqPorts-1:0] tcdm_rsp_q_ready;
+  logic [TCDMReqPorts-1:0] tcdm_rsp_p_valid;
+  logic [TCDMReqPorts-1:0][NarrowDataWidth-1:0] tcdm_rsp_data;
+
+  logic tcdm_dma_req_write_i;
+  logic [TCDMAddrWidth-1:0] tcdm_dma_req_addr_i;
+  logic [WideDataWidth-1:0] tcdm_dma_req_data_i;
+  logic [WideDataWidth/8-1:0] tcdm_dma_req_strb_i;
+  logic tcdm_dma_req_q_valid_i;
+  logic tcdm_dma_rsp_q_ready_o;
+  logic tcdm_dma_rsp_p_valid_o;
+  logic [WideDataWidth-1:0] tcdm_dma_rsp_data_o;
+
+  // TCDM subsystem
+  tcdm_subsys #(
+    .NarrowDataWidth ( NarrowDataWidth ),
+    .TCDMDepth ( TCDMDepth ),
+    .TCDMAddrWidth ( TCDMAddrWidth ),
+    .NrBanks ( NrBanks ),
+    .NumInp ( TCDMReqPorts )
+  ) i_tcdm_subsys (
+    //-----------------------------
+    // Clock and reset
+    //-----------------------------
+    .clk_i ( clk_i ),
+    .rst_ni ( rst_ni ),
+    //-----------------------------
+    // TCDM ports
+    //-----------------------------
+    .tcdm_req_write_i ( tcdm_req_write ),
+    .tcdm_req_addr_i ( tcdm_req_addr ),
+    .tcdm_req_amo_i ( tcdm_req_amo ),
+    .tcdm_req_data_i ( tcdm_req_data ),
+    .tcdm_req_user_core_id_i ( tcdm_req_user_core_id ),
+    .tcdm_req_user_is_core_i ( tcdm_req_user_is_core ),
+    .tcdm_req_strb_i ( tcdm_req_strb ),
+    .tcdm_req_q_valid_i ( tcdm_req_q_valid ),
+    .tcdm_rsp_q_ready_o ( tcdm_rsp_q_ready ),
+    .tcdm_rsp_p_valid_o ( tcdm_rsp_p_valid ),
+    .tcdm_rsp_data_o ( tcdm_rsp_data ),
+    //-----------------------------
+    // Wide TCDM ports
+    //-----------------------------
+    .tcdm_dma_req_write_i ( tcdm_dma_req_write_i ),
+    .tcdm_dma_req_addr_i ( tcdm_dma_req_addr_i ),
+    .tcdm_dma_req_data_i ( tcdm_dma_req_data_i ),
+    .tcdm_dma_req_strb_i ( tcdm_dma_req_strb_i ),
+    .tcdm_dma_req_q_valid_i ( tcdm_dma_req_q_valid_i ),
+    .tcdm_dma_rsp_q_ready_o ( tcdm_dma_rsp_q_ready_o ),
+    .tcdm_dma_rsp_p_valid_o ( tcdm_dma_rsp_p_valid_o ),
+    .tcdm_dma_rsp_data_o ( tcdm_dma_rsp_data_o )
+  );
+
+  stream_mul_wrapper #(
+    .NarrowDataWidth ( NarrowDataWidth ),
+    .TCDMDepth ( TCDMDepth ),
+    .TCDMReqPorts ( TCDMReqPorts ),
+    .TCDMSize ( TCDMSize ),
+    .TCDMAddrWidth ( TCDMAddrWidth )
+  ) i_stream_mul_wrapper (
+    //-----------------------------
+    // Clocks and reset
+    //-----------------------------
+    .clk_i ( clk_i ),
+    .rst_ni ( rst_ni ),
+
+    //-----------------------------
+    // TCDM ports
+    //-----------------------------
+    // Request
+    .tcdm_req_write_o ( tcdm_req_write ),
+    .tcdm_req_addr_o ( tcdm_req_addr ),
+    .tcdm_req_amo_o ( tcdm_req_amo ), 
+    .tcdm_req_data_o ( tcdm_req_data ),
+    .tcdm_req_user_core_id_o ( tcdm_req_user_core_id ), 
+    .tcdm_req_user_is_core_o ( tcdm_req_user_is_core ),
+    .tcdm_req_strb_o ( tcdm_req_strb ),
+    .tcdm_req_q_valid_o ( tcdm_req_q_valid ),
+    // Response
+    .tcdm_rsp_q_ready_i ( tcdm_rsp_q_ready ),
+    .tcdm_rsp_p_valid_i ( tcdm_rsp_p_valid ),
+    .tcdm_rsp_data_i ( tcdm_rsp_data ),
+
+    //-----------------------------
+    // CSR control ports
+    //-----------------------------
+    // Request
+    .io_csr_req_bits_data_i ( io_csr_req_bits_data_i ),
+    .io_csr_req_bits_addr_i ( io_csr_req_bits_addr_i ),
+    .io_csr_req_bits_write_i ( io_csr_req_bits_write_i ),
+    .io_csr_req_valid_i ( io_csr_req_valid_i ),
+    .io_csr_req_ready_o ( io_csr_req_ready_o ),
+    // Response
+    .io_csr_rsp_ready_i ( io_csr_rsp_ready_i ),
+    .io_csr_rsp_valid_o ( io_csr_rsp_valid_o ),
+    .io_csr_rsp_bits_data_o ( io_csr_rsp_bits_data_o )
+  );
+
+endmodule


### PR DESCRIPTION
This PR adds a sample template combination of a TCDM subsystem, streamer, and a simple streaming multiplier.

It contains the simple multiplier and its wrapper.

- The simple multiplier takes in 2 inputs and one output. It uses the valid-ready protocol to take in data.
- The wrapper extends the MAC into multiple parallel cores
- A test to test the entire setup
- Minor modifications for code clean up