### PR TITLE
Fix RTL bugs

### DIFF
--- a/rtl/rtl-util/csr_mux_demux.sv
+++ b/rtl/rtl-util/csr_mux_demux.sv
@@ -72,7 +72,7 @@ module csr_mux_demux #(
   // We take the upper part ports to have priority
   // This is just for simplicity's sake
   //-------------------------------
-  always begin
+  always_comb begin
     // For read and valid ports
     csr_rsp_data_o  = ( acc_csr_rsp_valid_i[1] ) ? acc_csr_rsp_data_i[1]  : acc_csr_rsp_data_i[0];
     csr_rsp_valid_o = ( acc_csr_rsp_valid_i[1] ) ? acc_csr_rsp_valid_i[1] : acc_csr_rsp_valid_i[0];

--- a/util/templates/streamer_wrapper.sv.tpl
+++ b/util/templates/streamer_wrapper.sv.tpl
@@ -16,7 +16,8 @@ module streamer_wrapper #(
   parameter int unsigned NarrowDataWidth = ${cfg["tcdmDataWidth"]},
   parameter int unsigned TCDMDepth = ${cfg["tcdmDepth"]},
   parameter int unsigned TCDMReqPorts = ${sum(cfg["dataReaderParams"]["tcdmPortsNum"]) + sum(cfg["dataWriterParams"]["tcdmPortsNum"])},
-  parameter int unsigned TCDMSize = TCDMReqPorts * TCDMDepth * (NarrowDataWidth/8),
+  parameter int unsigned NrBanks = ${cfg["numBanks"]},
+  parameter int unsigned TCDMSize = NrBanks * TCDMDepth * (NarrowDataWidth/8),
   parameter int unsigned TCDMAddrWidth = $clog2(TCDMSize)
 )(
 


### PR DESCRIPTION
This PR fixes a few loose ends:

* Missing `always_comb` from `csr_mux_demux`
* Refactoring TCDM size from `straemer_wrapper.sv.tpl`